### PR TITLE
re-deliver duplicate message if it was not acknowledged by the user, ignore otherwise

### DIFF
--- a/src/Simplex/Messaging/Agent.hs
+++ b/src/Simplex/Messaging/Agent.hs
@@ -524,7 +524,7 @@ ackMessage' c connId msgId = do
     ack :: RcvQueue -> m ()
     ack rq = do
       let mId = InternalId msgId
-      srvMsgId <- withStore $ \st -> checkRcvMsg st connId mId
+      srvMsgId <- withStore $ \st -> setMsgUserAck st connId mId
       sendAck c rq srvMsgId `catchError` \case
         SMP SMP.NO_MSG -> pure ()
         e -> throwError e
@@ -744,15 +744,27 @@ processSMPTransmission c@AgentClient {smpClients, subQ} (srv, sessId, rId, cmd) 
             (Just e2eDh, Nothing) -> do
               decryptClientMessage e2eDh clientMsg >>= \case
                 (SMP.PHEmpty, AgentMsgEnvelope _ encAgentMsg) ->
-                  agentClientMsg >>= \case
-                    Just (msgId, msgMeta, aMessage) -> case aMessage of
+                  tryError agentClientMsg >>= \case
+                    Right (Just (msgId, msgMeta, aMessage)) -> case aMessage of
                       HELLO -> helloMsg >> ack >> withStore (\st -> deleteMsg st connId msgId)
                       REPLY cReq -> replyMsg cReq >> ack >> withStore (\st -> deleteMsg st connId msgId)
                       -- note that there is no ACK sent for A_MSG, it is sent with agent's user ACK command
                       A_MSG body -> do
                         logServer "<--" c srv rId "MSG <MSG>"
                         notify $ MSG msgMeta msgFlags body
-                    _ -> prohibited >> ack
+                    Right _ -> prohibited >> ack
+                    Left e@(AGENT A_DUPLICATE) -> do
+                      withStore (\st -> getLastMsg st connId srvMsgId) >>= \case
+                        Just RcvMsg {userAck, msgMeta, msgBody = agentMsgBody}
+                          | userAck -> ack
+                          | otherwise -> do
+                            liftEither (parse smpP (AGENT A_MESSAGE) agentMsgBody) >>= \case
+                              AgentMessage _ (A_MSG body) -> do
+                                logServer "<--" c srv rId "MSG <MSG>"
+                                notify $ MSG msgMeta msgFlags body
+                              _ -> pure ()
+                        _ -> throwError e
+                    Left e -> throwError e
                   where
                     agentClientMsg :: m (Maybe (InternalId, MsgMeta, AMessage))
                     agentClientMsg = withStore $ \st -> do
@@ -767,7 +779,7 @@ processSMPTransmission c@AgentClient {smpClients, subQ} (srv, sessId, rId, cmd) 
                               recipient = (unId internalId, internalTs)
                               broker = (srvMsgId, systemToUTCTime srvTs)
                               msgMeta = MsgMeta {integrity, recipient, broker, sndMsgId}
-                              rcvMsg = RcvMsgData {msgMeta, msgType, msgFlags, msgBody, internalRcvId, internalHash, externalPrevSndHash = prevMsgHash}
+                              rcvMsg = RcvMsgData {msgMeta, msgType, msgFlags, msgBody = agentMsgBody, internalRcvId, internalHash, externalPrevSndHash = prevMsgHash}
                           createRcvMsg st connId rcvMsg
                           pure $ Just (internalId, msgMeta, aMessage)
                         _ -> pure Nothing

--- a/src/Simplex/Messaging/Agent/Client.hs
+++ b/src/Simplex/Messaging/Agent/Client.hs
@@ -574,5 +574,5 @@ cryptoError = \case
   C.CryptoHeaderError _ -> AGENT A_ENCRYPTION
   C.AESDecryptError -> AGENT A_ENCRYPTION
   C.CBDecryptError -> AGENT A_ENCRYPTION
-  -- C.CERatchetDuplicateMessage -> AGENT A_DUPLICATE
+  C.CERatchetDuplicateMessage -> AGENT A_DUPLICATE
   e -> INTERNAL $ show e

--- a/src/Simplex/Messaging/Agent/Store.hs
+++ b/src/Simplex/Messaging/Agent/Store.hs
@@ -70,7 +70,8 @@ class Monad m => MonadAgentStore s m where
   createSndMsg :: s -> ConnId -> SndMsgData -> m ()
   getPendingMsgData :: s -> ConnId -> InternalId -> m (Maybe RcvQueue, PendingMsgData)
   getPendingMsgs :: s -> ConnId -> m [InternalId]
-  checkRcvMsg :: s -> ConnId -> InternalId -> m MsgId
+  setMsgUserAck :: s -> ConnId -> InternalId -> m MsgId
+  getLastMsg :: s -> ConnId -> SMP.MsgId -> m (Maybe RcvMsg)
   deleteMsg :: s -> ConnId -> InternalId -> m ()
 
   -- Double ratchet persistence
@@ -247,7 +248,7 @@ type PrevRcvMsgHash = MsgHash
 -- | Corresponds to `last_snd_msg_hash` in `connections` table
 type PrevSndMsgHash = MsgHash
 
--- * Message data containers - used on Msg creation to reduce number of parameters
+-- * Message data containers
 
 data RcvMsgData = RcvMsgData
   { msgMeta :: MsgMeta,
@@ -257,6 +258,12 @@ data RcvMsgData = RcvMsgData
     internalRcvId :: InternalRcvId,
     internalHash :: MsgHash,
     externalPrevSndHash :: MsgHash
+  }
+
+data RcvMsg = RcvMsg
+  { msgMeta :: MsgMeta,
+    msgBody :: MsgBody,
+    userAck :: Bool
   }
 
 data SndMsgData = SndMsgData

--- a/src/Simplex/Messaging/Agent/Store/SQLite/Migrations/M20220608_v2.hs
+++ b/src/Simplex/Messaging/Agent/Store/SQLite/Migrations/M20220608_v2.hs
@@ -13,4 +13,6 @@ ALTER TABLE messages ADD COLUMN msg_flags TEXT NULL;
 ALTER TABLE conn_confirmations ADD COLUMN smp_reply_queues BLOB NULL;
 
 ALTER TABLE connections ADD COLUMN duplex_handshake INTEGER NULL DEFAULT 0;
+
+ALTER TABLE rcv_messages ADD COLUMN user_ack INTEGER NULL DEFAULT 0;
 |]

--- a/src/Simplex/Messaging/Agent/Store/SQLite/Migrations/agent_schema.sql
+++ b/src/Simplex/Messaging/Agent/Store/SQLite/Migrations/agent_schema.sql
@@ -83,6 +83,7 @@ CREATE TABLE rcv_messages(
   internal_hash BLOB NOT NULL,
   external_prev_snd_hash BLOB NOT NULL,
   integrity BLOB NOT NULL,
+  user_ack INTEGER NULL DEFAULT 0,
   PRIMARY KEY(conn_id, internal_rcv_id),
   FOREIGN KEY(conn_id, internal_id) REFERENCES messages
   ON DELETE CASCADE


### PR DESCRIPTION
This handles the scenario when the agent received and decrypted message but did not acknowledged it to the server.

In this case the server would re-deliver it.

Previously, as the ratchet already advanced, the decryption would fail, and the error sent to the user, visible in CLI and ignored in mobile UI.

If the message was already saved in chat db it is not a problem, but if it wasn't - it is lost.

This PR:
- adds a flag whether the message was ACK'd by the user (and from it follows that the agent failed sending ACK to the server)
- saves decrypted message body (previously, encrypted body was sent) until the message is acknowledged
- this is not changing the database security, as it is saved to chat db decrypted too.
- if the message was acknowledged by the user, then ack is sent to the user, and the message is deleted
- if not, the message is sent to the user again. The scenario when the chat saved the message but failed to send ACK to the agent is much less likely.