### PR TITLE
Remove duplicated serverIdentity field

### DIFF
--- a/src/Simplex/Messaging/Notifications/Server/Env.hs
+++ b/src/Simplex/Messaging/Notifications/Server/Env.hs
@@ -65,7 +65,6 @@ data NtfEnv = NtfEnv
     store :: NtfStore,
     storeLog :: Maybe (StoreLog 'WriteMode),
     idsDrg :: TVar ChaChaDRG,
-    serverIdentity :: C.KeyHash,
     tlsServerParams :: T.ServerParams,
     serverIdentity :: C.KeyHash
   }


### PR DESCRIPTION
This change fixes this compilation issue:

```
src/Simplex/Messaging/Notifications/Server/Env.hs:70:5: error:
    Multiple declarations of ‘serverIdentity’
    Declared at: src/Simplex/Messaging/Notifications/Server/Env.hs:68:5
                 src/Simplex/Messaging/Notifications/Server/Env.hs:70:5
   |
70 |     serverIdentity :: C.KeyHash
   |     ^^^^^^^^^^^^^^
```