### PR TITLE
Support for building ARM docker images

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:focal AS build
 ### Build stage
 
 # Install curl and git and smp-related dependencies
-RUN apt-get update && apt-get install -y curl git build-essential libgmp3-dev zlib1g-dev llvm-11 llvm-11-dev libnuma-dev
+RUN apt-get update && apt-get install -y curl git build-essential libgmp3-dev zlib1g-dev llvm llvm-dev libnuma-dev
 
 # Install ghcup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=8.10.7 BOOTSTRAP_HASKELL_CABAL_VERSION=3.6.2.0 sh

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -28,7 +28,7 @@ RUN cabal install
 FROM final
 
 # Install OpenSSL dependency
-RUN apt-get update && apt-get install -y openssl
+RUN apt-get update && apt-get install -y openssl libnuma-dev
 
 # Copy compiled smp-server from build stage
 COPY --from=build /root/.cabal/bin/smp-server /usr/bin/smp-server

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -7,22 +7,17 @@ FROM ubuntu:focal AS build
 RUN apt-get update && apt-get install -y curl git build-essential libgmp3-dev zlib1g-dev llvm-11 llvm-11-dev
 
 # Install ghcup
-RUN curl https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup -o /usr/bin/ghcup && \
-    chmod +x /usr/bin/ghcup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=8.10.7 BOOTSTRAP_HASKELL_CABAL_VERSION=3.6.2.0 sh
 
-# Install ghc
-RUN ghcup install ghc 8.10.7
-# Install cabal
-RUN ghcup install cabal
+# Adjust PATH
+ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
+
 # Set both as default
 RUN ghcup set ghc 8.10.7 && \
     ghcup set cabal
 
 COPY . /project
 WORKDIR /project
-
-# Adjust PATH
-ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
 
 # Compile smp-server
 RUN cabal update

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:focal AS build
 ### Build stage
 
 # Install curl and git and smp-related dependencies
-RUN apt-get update && apt-get install -y curl git build-essential libgmp3-dev zlib1g-dev llvm-11 llvm-11-dev
+RUN apt-get update && apt-get install -y curl git build-essential libgmp3-dev zlib1g-dev llvm-11 llvm-11-dev libnuma-dev
 
 # Install ghcup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=8.10.7 BOOTSTRAP_HASKELL_CABAL_VERSION=3.6.2.0 sh

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:focal AS build
 ### Build stage
 
 # Install curl and git and smp-related dependencies
-RUN apt-get update && apt-get install -y curl git build-essential libgmp3-dev zlib1g-dev
+RUN apt-get update && apt-get install -y curl git build-essential libgmp3-dev zlib1g-dev llvm-11 llvm-11-dev
 
 # Install ghcup
 RUN curl https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup -o /usr/bin/ghcup && \


### PR DESCRIPTION
Currently Docker images are x86_64/amd64 only. This PR enables ARMv8 images to easily be built. Currently only tested building ARM images on Apple Silicon, but I tested the generated images on both a Raspberry Pi 4 and M1 Pro, in other words you can now run SimpleXMQ using docker on Raspberry Pi and Apple Silicon machines (and others?).

I also confirmed that this doesn't break existing x86_64 builds - although I only tested on 64-bit Ubuntu 22.04.2 

A test artifact can be found on Docker's registry `docker pull shyfire131/smp-server-arm`

The commits have been split up and should be self explanatory. 

Should fix https://github.com/simplex-chat/simplexmq/issues/678

Hopefully this will also enable you guys to publish arm images to Docker Hub?