### PR TITLE
Add GH Actions workflow to build and push Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,14 +25,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: linux/arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Extract metadata for Docker image
         id: meta
         uses: docker/metadata-action@v4
@@ -50,6 +42,5 @@ jobs:
         with:
           push: true
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Build and push SimpleXMQ Docker image
+name: Build and push Docker image to Docker Hub
 
 on:
   push:
@@ -7,8 +7,14 @@ on:
 
 jobs:
   build-and-push:
-    name: Build and push Docker image to Docker Hub
+    name: Build and push Docker image
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - application: simplexmq
+            dockerfile: build.Dockerfile
     steps:
       - name: Clone project
         uses: actions/checkout@v3
@@ -31,7 +37,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/simplexmq
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.application }}
           flavor: |
             latest=auto
           tags: |
@@ -43,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          file: build.Dockerfile
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64,linux/386
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: linux/arm64,linux/386
+          platforms: linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -50,6 +50,6 @@ jobs:
         with:
           push: true
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64,linux/386
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,49 @@
+name: Build and push SimpleXMQ Docker image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-push:
+    name: Build and push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/arm64,linux/386
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract metadata for Docker image
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/simplexmq
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          file: build.Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/386
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - application: simplexmq
+          - application: smp-server
             dockerfile: build.Dockerfile
     steps:
       - name: Clone project


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that will automatically build and push a Docker image to Docker Hub on every release. It creates four image tags:

- `vX`: The latest minor version under the specified major version
- `vX.Y`: The latest patch version under the specified minor version
- `vX.Y.Z`: The specified full version
- `latest`: Follows the latest release

It builds the image for Linux platform x64.

The only thing that you need to do is to:

- Set the repo secret `DOCKERHUB_USERNAME` to the username of your Docker Hub account
- Set the repo secret `DOCKERHUB_PASSWORD` to the password of your Docker Hub account

I have used a matrix to specify the application to be built and the Dockerfile that should be used. If you want to extend the workflow to build more applications, such as XFTP, just add a new entry to the matrix. Currently it only builds SimpleXMQ.

Closes #732.