### PR TITLE
docker: rewrite entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,15 @@ On Linux, you can deploy smp server using Docker. This will download image from 
    mkdir -p ~/simplex/{config,logs}
    ```
 
-2. Run your Docker container. You must change **your_ip_or_domain**. `-e "pass=password"` is optional variable to password-protect your `smp` server:
+2. Run your Docker container. You must provide **your_domain** using ADDR or **your_ip** using IP. `-e 'PASS=password'` is optional variable to password-protect your `smp` server:
    ```sh
    docker run -d \
-       -e "addr=your_ip_or_domain" \
-       -e "pass=password" \
+       -e 'ADDR=your_domain' \
+       -e 'IP=your_ip' \
+       -e 'PASS=password' \
        -p 5223:5223 \
-       -v $HOME/simplex/config:/etc/opt/simplex:z \
-       -v $HOME/simplex/logs:/var/opt/simplex:z \
+       -v "${HOME}/simplex/config:/etc/opt/simplex:z" \
+       -v "${HOME}/simplex/logs:/var/opt/simplex:z" \
        simplexchat/smp-server:latest
    ```
 
@@ -151,14 +152,15 @@ On Linux, you can build smp server using Docker.
    mkdir -p ~/simplex/{config,logs}
    ```
 
-3. Run your Docker container. You must change **your_ip_or_domain**. `-e pass="password"` is optional variable to password-protect your `smp` server::
+3. Run your Docker container. You must provide **your_domain** using ADDR or **your_ip** using IP. `-e 'PASS=password'` is optional variable to password-protect your `smp` server::
    ```sh
    docker run -d \
-       -e "addr=your_ip_or_domain" \
-       -e "pass=password" \
+       -e 'ADDR=your_domain' \
+       -e 'IP=your_ip' \
+       -e 'PASS=password' \
        -p 5223:5223 \
-       -v $HOME/simplex/config:/etc/opt/simplex:z \
-       -v $HOME/simplex/logs:/var/opt/simplex:z \
+       -v "${HOME}/simplex/config:/etc/opt/simplex:z" \
+       -v "${HOME}/simplex/logs:/var/opt/simplex:z" \
        smp-server
    ```
 

--- a/scripts/docker/entrypoint
+++ b/scripts/docker/entrypoint
@@ -1,26 +1,37 @@
 #!/usr/bin/env sh
-confd="/etc/opt/simplex"
-logd="/var/opt/simplex/"
+confd='/etc/opt/simplex'
+logd='/var/opt/simplex/'
 
 # Check if server has been initialized
-if [ ! -f "$confd/smp-server.ini" ]; then
+if [ ! -f "${confd}/smp-server.ini" ]; then
   # If not, determine ip or domain
-  case $addr in
-    '') printf "Please specify \$addr environment variable.\n"; exit 1 ;;
-    *[a-zA-Z]*) set -- -n $addr ;;
-    *) set -- --ip $addr ;;
-  esac
+  if [ -n "${ADDR}" ] || [ -n "${IP}" ]; then
+    if [ -n "${ADDR}" ]; then
+      set -- -n "${ADDR}"
+    fi
+    if [ -n "${IP}" ]; then
+      set -- --ip "${IP}"
+    fi
+  else
+    printf 'Please specify either $ADDR or $IP environment variable.\n'
+    exit 1
+  fi
 
-  case $pass in
-    '') set -- "$@" --no-password ;;
-    *) set -- "$@" --password $pass ;;
-  esac
+  if [ -n "${PASS}" ]; then
+    set -- "$@" --password "${PASS}"
+  else
+    set -- "$@" --no-password
+  fi
 
   smp-server init -y -l "$@"
 fi
 
 # backup store log
-[ -f "$logd/smp-server-store.log" ] && cp "$logd"/smp-server-store.log "$logd"/smp-server-store.log."$(date +'%FT%T')"
+if [ -f "${logd}/smp-server-store.log" ]; then
+  _ext="$(date +'%FT%T')"
+  cp -v "${logd}/smp-server-store.log" "${logd}/smp-server-store.log.${_ext:-date-failed.$$}"
+  unset -v _ext
+fi
 
 # Finally, run smp-sever. Notice that "exec" here is important:
 # smp-server replaces our helper script, so that it can catch INT signal


### PR DESCRIPTION
Rewritten to prefer understanding by inexperienced users:

- use single quotes wherever possible
- do not escape variable usage
- use explicit tests and logic
- always use braces for custom variables
- capitalize environment variables
- use consistent quoting

A password containing spaces should not cause errors.

When date fails, leave a file that explains what happened rather than a mystery.

Prefer `IP` over `ADDR` when both are provided.

This fixes how guessing if `addr` was an IP or not can go badly by letting the user explicitly specify that they want to use an IP address with a distinct environment variable.