### PR TITLE
Pin GHC version in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,5 @@
+with-compiler: ghc-8.10.7
+
 packages: .
 -- packages: . ../direct-sqlcipher ../sqlcipher-simple
 -- packages: . ../hs-socks


### PR DESCRIPTION
Allows building without switching user-preferred version.