### PR TITLE
Add env lookups for smp server paths

### DIFF
--- a/apps/smp-server/Main.hs
+++ b/apps/smp-server/Main.hs
@@ -21,8 +21,7 @@ main = do
   setLogLevel LogDebug
   cfgPath <- getEnvPath "SMP_SERVER_CFG_PATH" defaultCfgPath
   logPath <- getEnvPath "SMP_SERVER_LOG_PATH" defaultLogPath
-  withGlobalLogging logCfg $
-    smpServerCLI cfgPath logPath
+  withGlobalLogging logCfg $ smpServerCLI cfgPath logPath
     
 getEnvPath :: String -> FilePath -> FilePath
 getEnvPath name def = maybe def (\case "" -> def; f -> f) <$> lookupEnv name

--- a/apps/smp-server/Main.hs
+++ b/apps/smp-server/Main.hs
@@ -1,13 +1,15 @@
 module Main where
 
 import Control.Logger.Simple
+import Data.Maybe
 import Simplex.Messaging.Server.Main
+import System.Environment
 
-cfgPath :: FilePath
-cfgPath = "/etc/opt/simplex"
+defaultCfgPath :: FilePath
+defaultCfgPath = "/etc/opt/simplex"
 
-logPath :: FilePath
-logPath = "/var/opt/simplex"
+defaultLogPath :: FilePath
+defaultLogPath = "/var/opt/simplex"
 
 logCfg :: LogConfig
 logCfg = LogConfig {lc_file = Nothing, lc_stderr = True}
@@ -15,4 +17,7 @@ logCfg = LogConfig {lc_file = Nothing, lc_stderr = True}
 main :: IO ()
 main = do
   setLogLevel LogDebug
-  withGlobalLogging logCfg $ smpServerCLI cfgPath logPath
+  cfgPath <- lookupEnv "SMP_SERVER_CFG_PATH"
+  logPath <- lookupEnv "SMP_SERVER_LOG_PATH"
+  withGlobalLogging logCfg $
+    smpServerCLI (fromMaybe defaultCfgPath cfgPath) (fromMaybe defaultLogPath logPath)

--- a/apps/smp-server/Main.hs
+++ b/apps/smp-server/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Main where
 
 import Control.Logger.Simple
@@ -17,7 +19,10 @@ logCfg = LogConfig {lc_file = Nothing, lc_stderr = True}
 main :: IO ()
 main = do
   setLogLevel LogDebug
-  cfgPath <- lookupEnv "SMP_SERVER_CFG_PATH"
-  logPath <- lookupEnv "SMP_SERVER_LOG_PATH"
+  cfgPath <- getEnvPath "SMP_SERVER_CFG_PATH" defaultCfgPath
+  logPath <- getEnvPath "SMP_SERVER_LOG_PATH" defaultLogPath
   withGlobalLogging logCfg $
-    smpServerCLI (fromMaybe defaultCfgPath cfgPath) (fromMaybe defaultLogPath logPath)
+    smpServerCLI cfgPath logPath
+    
+getEnvPath :: String -> FilePath -> FilePath
+getEnvPath name def = maybe def (\case "" -> def; f -> f) <$> lookupEnv name

--- a/apps/smp-server/Main.hs
+++ b/apps/smp-server/Main.hs
@@ -23,5 +23,5 @@ main = do
   logPath <- getEnvPath "SMP_SERVER_LOG_PATH" defaultLogPath
   withGlobalLogging logCfg $ smpServerCLI cfgPath logPath
     
-getEnvPath :: String -> FilePath -> FilePath
+getEnvPath :: String -> FilePath -> IO FilePath
 getEnvPath name def = maybe def (\case "" -> def; f -> f) <$> lookupEnv name


### PR DESCRIPTION
Allows running smp-server without touching system paths. Can be helpful for running multiple instances.