### PR TITLE
Upgrade to ghc 9.4.5

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,8 +5,8 @@ packages: .
 
 source-repository-package
     type: git
-    location: https://github.com/simplex-chat/aeson.git
-    tag: 3eb66f9a68f103b5f1489382aad89f5712a64db7
+    location: https://github.com/JonathanLorimer/aeson.git
+    tag: b6634ea9c8960d2dab4dc0e1ab76bbfe23fba928
 
 source-repository-package
     type: git

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,117 @@
+{
+  "nodes": {
+    "aeson-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1691447481,
+        "narHash": "sha256-BAgyGuXdoHEZFpLJnA9awkTAmz5ZIRARZwqe4pnN5fY=",
+        "owner": "JonathanLorimer",
+        "repo": "aeson",
+        "rev": "b6634ea9c8960d2dab4dc0e1ab76bbfe23fba928",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JonathanLorimer",
+        "repo": "aeson",
+        "rev": "b6634ea9c8960d2dab4dc0e1ab76bbfe23fba928",
+        "type": "github"
+      }
+    },
+    "direct-sqlcipher-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661865205,
+        "narHash": "sha256-zTlbfYHi2YzgX8r46c6Ur8CQX9Ul0Edbj1RY7Tysk08=",
+        "owner": "simplex-chat",
+        "repo": "direct-sqlcipher",
+        "rev": "34309410eb2069b029b8fc1872deb1e0db123294",
+        "type": "github"
+      },
+      "original": {
+        "owner": "simplex-chat",
+        "repo": "direct-sqlcipher",
+        "rev": "34309410eb2069b029b8fc1872deb1e0db123294",
+        "type": "github"
+      }
+    },
+    "hs-socks-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673127458,
+        "narHash": "sha256-aEgouR5om+yElV5efcsLi+4plvq7qimrOTOkd7LdWnk=",
+        "owner": "simplex-chat",
+        "repo": "hs-socks",
+        "rev": "a30cc7a79a08d8108316094f8f2f82a0c5e1ac51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "simplex-chat",
+        "repo": "hs-socks",
+        "rev": "a30cc7a79a08d8108316094f8f2f82a0c5e1ac51",
+        "type": "github"
+      }
+    },
+    "http2-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680780147,
+        "narHash": "sha256-6zubMhgzsCTKXMht+Pbfoc1OPtvFMUycJcaqUyQoCzc=",
+        "owner": "kazu-yamamoto",
+        "repo": "http2",
+        "rev": "b5a1b7200cf5bc7044af34ba325284271f6dff25",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kazu-yamamoto",
+        "repo": "http2",
+        "rev": "b5a1b7200cf5bc7044af34ba325284271f6dff25",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1691403902,
+        "narHash": "sha256-J74y4xWtKPDPyVtF4arzrwuSOGznlFlJ+uB9RwNNnbo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c91024273f020df2dcb209cc133461ca17848026",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "aeson-src": "aeson-src",
+        "direct-sqlcipher-src": "direct-sqlcipher-src",
+        "hs-socks-src": "hs-socks-src",
+        "http2-src": "http2-src",
+        "nixpkgs": "nixpkgs",
+        "sqlcipher-simple-src": "sqlcipher-simple-src"
+      }
+    },
+    "sqlcipher-simple-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661865375,
+        "narHash": "sha256-oAK4Hl+3arynrhWtc49PbfOlQ69aqgAQeHiTrnhhL7Q=",
+        "owner": "simplex-chat",
+        "repo": "sqlcipher-simple",
+        "rev": "5e154a2aeccc33ead6c243ec07195ab673137221",
+        "type": "github"
+      },
+      "original": {
+        "owner": "simplex-chat",
+        "repo": "sqlcipher-simple",
+        "rev": "5e154a2aeccc33ead6c243ec07195ab673137221",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,98 @@
+{
+  description = "simplexmq";
+
+  inputs = {
+    # Nix Inputs
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    aeson-src = {
+      url = "github:JonathanLorimer/aeson/b6634ea9c8960d2dab4dc0e1ab76bbfe23fba928";
+      flake = false;
+    };
+    hs-socks-src = {
+      url = "github:simplex-chat/hs-socks/a30cc7a79a08d8108316094f8f2f82a0c5e1ac51";
+      flake = false;
+    };
+    http2-src = {
+      url = "github:kazu-yamamoto/http2/b5a1b7200cf5bc7044af34ba325284271f6dff25";
+      flake = false;
+    };
+    direct-sqlcipher-src = {
+      url = "github:simplex-chat/direct-sqlcipher/34309410eb2069b029b8fc1872deb1e0db123294";
+      flake = false;
+    };
+    sqlcipher-simple-src = {
+      url = "github:simplex-chat/sqlcipher-simple/5e154a2aeccc33ead6c243ec07195ab673137221";
+      flake = false;
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    aeson-src,
+    hs-socks-src,
+    http2-src,
+    direct-sqlcipher-src,
+    sqlcipher-simple-src
+  }: 
+    let
+      forAllSystems = function:
+        nixpkgs.lib.genAttrs [
+          "x86_64-linux"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "aarch64-darwin"
+        ] (system: function rec {
+          inherit system;
+          compilerVersion = "ghc94";
+          pkgs = nixpkgs.legacyPackages.${system};
+          
+          hsPkgs = pkgs.haskell.packages.${compilerVersion}.override {
+            overrides = hfinal: hprev: with pkgs.haskell.lib; {
+              simplexmq = hfinal.callCabal2nix "simplexmq" ./. {};
+              aeson = dontCheck (hfinal.callCabal2nix "aeson" "${aeson-src}" {});
+              hs-socks = hfinal.callCabal2nix "hs-socks" "${hs-socks-src}" {};
+              http2 = hfinal.callCabal2nix "http2" "${http2-src}" {};
+              direct-sqlcipher = dontCheck (hfinal.callCabal2nix "direct-sqlcipher" "${direct-sqlcipher-src}" {});
+              sqlcipher-simple = dontCheck (hfinal.callCabal2nix "sqlcipher-simple" "${sqlcipher-simple-src}" {});
+            };
+          };
+        });
+    in
+    {
+      # nix fmt
+      formatter = forAllSystems ({pkgs, ...}: pkgs.alejandra);
+
+      # nix develop
+      devShells = forAllSystems ({hsPkgs, pkgs, system, ...}: {
+        default = 
+          hsPkgs.shellFor {
+            packages = p: [
+              p.simplexmq
+            ];
+            buildInputs = with pkgs;
+              [
+                hsPkgs.haskell-language-server
+                haskellPackages.cabal-install
+                hpack
+                # cabal2nix
+                haskellPackages.ghcid
+              ];
+        };
+      });
+
+      # nix build
+      packages = forAllSystems ({hsPkgs, ...}: {
+          simplexmq = hsPkgs.simplexmq;
+          default = hsPkgs.simplexmq;
+      });
+
+      # You can't build the cfg package as a check because of IFD in cabal2nix
+      checks = {};
+
+      # nix run
+      apps = forAllSystems ({system, ...}: {
+        #TODO: add all the different bins here
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,6 @@
                 hsPkgs.haskell-language-server
                 haskellPackages.cabal-install
                 hpack
-                # cabal2nix
                 haskellPackages.ghcid
               ];
         };

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,14 @@
+cradle:
+  cabal:
+    - path: "./src"
+      component: "lib:simplexmq"
+    - path: "./apps/smp-server"
+      component: "exe:smp-server"
+    - path: "./apps/ntf-server"
+      component: "exe:ntf-server"
+    - path: "./apps/xftp-server"
+      component: "exe:xftp-server"
+    - path: "./apps/xftp"
+      component: "exe:xftp"
+    - path: "./tests"
+      component: "test:simplexmq-test"

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,7 @@ extra-source-files:
   - CHANGELOG.md
 
 dependencies:
-  - aeson == 2.0.*
+  - aeson == 2.1.*
   - ansi-terminal >= 0.10 && < 0.12
   - asn1-encoding == 0.9.*
   - asn1-types == 0.3.*
@@ -30,12 +30,12 @@ dependencies:
   - attoparsec == 0.14.*
   - base >= 4.14 && < 5
   - base64-bytestring >= 1.0 && < 1.3
-  - bytestring == 0.10.*
+  - bytestring == 0.11.*
   - case-insensitive == 1.2.*
   - composition == 1.0.*
   - constraints >= 0.12 && < 0.14
   - containers == 0.6.*
-  - cryptonite >= 0.27 && < 0.30
+  - cryptonite >= 0.30
   - cryptostore == 0.2.*
   - data-default == 0.7.*
   - direct-sqlcipher == 2.3.*
@@ -43,14 +43,14 @@ dependencies:
   - filepath == 1.4.*
   - http-types == 0.12.*
   - http2 == 4.1.*
-  - generic-random >= 1.3 && < 1.5
+  - generic-random == 1.5.*
   - ini == 0.4.1
   - iproute == 1.7.*
   - iso8601-time == 0.1.*
-  - memory == 0.15.*
+  - memory == 0.18.*
   - mtl == 2.2.*
   - network >= 3.1.2.7 && < 3.2
-  - network-transport == 0.5.4
+  - network-transport == 0.5.6
   - optparse-applicative >= 0.15 && < 0.17
   - QuickCheck == 2.14.*
   - process == 1.6.*
@@ -59,9 +59,9 @@ dependencies:
   - socks == 0.6.*
   - sqlcipher-simple == 0.4.*
   - stm == 2.5.*
-  - template-haskell == 2.16.*
+  - template-haskell == 2.19.*
   - temporary == 1.3.*
-  - text == 1.2.*
+  - text == 2.0.*
   - time == 1.9.*
   - time-compat == 1.9.*
   - time-manager == 0.0.*

--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -140,7 +140,7 @@ library
   ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns
   build-depends:
       QuickCheck ==2.14.*
-    , aeson ==2.0.*
+    , aeson ==2.1.*
     , ansi-terminal >=0.10 && <0.12
     , asn1-encoding ==0.9.*
     , asn1-types ==0.3.*
@@ -148,27 +148,27 @@ library
     , attoparsec ==0.14.*
     , base >=4.14 && <5
     , base64-bytestring >=1.0 && <1.3
-    , bytestring ==0.10.*
+    , bytestring ==0.11.*
     , case-insensitive ==1.2.*
     , composition ==1.0.*
     , constraints >=0.12 && <0.14
     , containers ==0.6.*
-    , cryptonite >=0.27 && <0.30
+    , cryptonite >=0.30
     , cryptostore ==0.2.*
     , data-default ==0.7.*
     , direct-sqlcipher ==2.3.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , generic-random >=1.3 && <1.5
+    , generic-random ==1.5.*
     , http-types ==0.12.*
     , http2 ==4.1.*
     , ini ==0.4.1
     , iproute ==1.7.*
     , iso8601-time ==0.1.*
-    , memory ==0.15.*
+    , memory ==0.18.*
     , mtl ==2.2.*
     , network >=3.1.2.7 && <3.2
-    , network-transport ==0.5.4
+    , network-transport ==0.5.6
     , optparse-applicative >=0.15 && <0.17
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -176,9 +176,9 @@ library
     , socks ==0.6.*
     , sqlcipher-simple ==0.4.*
     , stm ==2.5.*
-    , template-haskell ==2.16.*
+    , template-haskell ==2.19.*
     , temporary ==1.3.*
-    , text ==1.2.*
+    , text ==2.0.*
     , time ==1.9.*
     , time-compat ==1.9.*
     , time-manager ==0.0.*
@@ -204,7 +204,7 @@ executable ntf-server
   ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
   build-depends:
       QuickCheck ==2.14.*
-    , aeson ==2.0.*
+    , aeson ==2.1.*
     , ansi-terminal >=0.10 && <0.12
     , asn1-encoding ==0.9.*
     , asn1-types ==0.3.*
@@ -212,27 +212,27 @@ executable ntf-server
     , attoparsec ==0.14.*
     , base >=4.14 && <5
     , base64-bytestring >=1.0 && <1.3
-    , bytestring ==0.10.*
+    , bytestring ==0.11.*
     , case-insensitive ==1.2.*
     , composition ==1.0.*
     , constraints >=0.12 && <0.14
     , containers ==0.6.*
-    , cryptonite >=0.27 && <0.30
+    , cryptonite >=0.30
     , cryptostore ==0.2.*
     , data-default ==0.7.*
     , direct-sqlcipher ==2.3.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , generic-random >=1.3 && <1.5
+    , generic-random ==1.5.*
     , http-types ==0.12.*
     , http2 ==4.1.*
     , ini ==0.4.1
     , iproute ==1.7.*
     , iso8601-time ==0.1.*
-    , memory ==0.15.*
+    , memory ==0.18.*
     , mtl ==2.2.*
     , network >=3.1.2.7 && <3.2
-    , network-transport ==0.5.4
+    , network-transport ==0.5.6
     , optparse-applicative >=0.15 && <0.17
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -241,9 +241,9 @@ executable ntf-server
     , socks ==0.6.*
     , sqlcipher-simple ==0.4.*
     , stm ==2.5.*
-    , template-haskell ==2.16.*
+    , template-haskell ==2.19.*
     , temporary ==1.3.*
-    , text ==1.2.*
+    , text ==2.0.*
     , time ==1.9.*
     , time-compat ==1.9.*
     , time-manager ==0.0.*
@@ -269,7 +269,7 @@ executable smp-agent
   ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
   build-depends:
       QuickCheck ==2.14.*
-    , aeson ==2.0.*
+    , aeson ==2.1.*
     , ansi-terminal >=0.10 && <0.12
     , asn1-encoding ==0.9.*
     , asn1-types ==0.3.*
@@ -277,27 +277,27 @@ executable smp-agent
     , attoparsec ==0.14.*
     , base >=4.14 && <5
     , base64-bytestring >=1.0 && <1.3
-    , bytestring ==0.10.*
+    , bytestring ==0.11.*
     , case-insensitive ==1.2.*
     , composition ==1.0.*
     , constraints >=0.12 && <0.14
     , containers ==0.6.*
-    , cryptonite >=0.27 && <0.30
+    , cryptonite >=0.30
     , cryptostore ==0.2.*
     , data-default ==0.7.*
     , direct-sqlcipher ==2.3.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , generic-random >=1.3 && <1.5
+    , generic-random ==1.5.*
     , http-types ==0.12.*
     , http2 ==4.1.*
     , ini ==0.4.1
     , iproute ==1.7.*
     , iso8601-time ==0.1.*
-    , memory ==0.15.*
+    , memory ==0.18.*
     , mtl ==2.2.*
     , network >=3.1.2.7 && <3.2
-    , network-transport ==0.5.4
+    , network-transport ==0.5.6
     , optparse-applicative >=0.15 && <0.17
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -306,9 +306,9 @@ executable smp-agent
     , socks ==0.6.*
     , sqlcipher-simple ==0.4.*
     , stm ==2.5.*
-    , template-haskell ==2.16.*
+    , template-haskell ==2.19.*
     , temporary ==1.3.*
-    , text ==1.2.*
+    , text ==2.0.*
     , time ==1.9.*
     , time-compat ==1.9.*
     , time-manager ==0.0.*
@@ -334,7 +334,7 @@ executable smp-server
   ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
   build-depends:
       QuickCheck ==2.14.*
-    , aeson ==2.0.*
+    , aeson ==2.1.*
     , ansi-terminal >=0.10 && <0.12
     , asn1-encoding ==0.9.*
     , asn1-types ==0.3.*
@@ -342,27 +342,27 @@ executable smp-server
     , attoparsec ==0.14.*
     , base >=4.14 && <5
     , base64-bytestring >=1.0 && <1.3
-    , bytestring ==0.10.*
+    , bytestring ==0.11.*
     , case-insensitive ==1.2.*
     , composition ==1.0.*
     , constraints >=0.12 && <0.14
     , containers ==0.6.*
-    , cryptonite >=0.27 && <0.30
+    , cryptonite >=0.30
     , cryptostore ==0.2.*
     , data-default ==0.7.*
     , direct-sqlcipher ==2.3.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , generic-random >=1.3 && <1.5
+    , generic-random ==1.5.*
     , http-types ==0.12.*
     , http2 ==4.1.*
     , ini ==0.4.1
     , iproute ==1.7.*
     , iso8601-time ==0.1.*
-    , memory ==0.15.*
+    , memory ==0.18.*
     , mtl ==2.2.*
     , network >=3.1.2.7 && <3.2
-    , network-transport ==0.5.4
+    , network-transport ==0.5.6
     , optparse-applicative >=0.15 && <0.17
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -371,9 +371,9 @@ executable smp-server
     , socks ==0.6.*
     , sqlcipher-simple ==0.4.*
     , stm ==2.5.*
-    , template-haskell ==2.16.*
+    , template-haskell ==2.19.*
     , temporary ==1.3.*
-    , text ==1.2.*
+    , text ==2.0.*
     , time ==1.9.*
     , time-compat ==1.9.*
     , time-manager ==0.0.*
@@ -399,7 +399,7 @@ executable xftp
   ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
   build-depends:
       QuickCheck ==2.14.*
-    , aeson ==2.0.*
+    , aeson ==2.1.*
     , ansi-terminal >=0.10 && <0.12
     , asn1-encoding ==0.9.*
     , asn1-types ==0.3.*
@@ -407,27 +407,27 @@ executable xftp
     , attoparsec ==0.14.*
     , base >=4.14 && <5
     , base64-bytestring >=1.0 && <1.3
-    , bytestring ==0.10.*
+    , bytestring ==0.11.*
     , case-insensitive ==1.2.*
     , composition ==1.0.*
     , constraints >=0.12 && <0.14
     , containers ==0.6.*
-    , cryptonite >=0.27 && <0.30
+    , cryptonite >=0.30
     , cryptostore ==0.2.*
     , data-default ==0.7.*
     , direct-sqlcipher ==2.3.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , generic-random >=1.3 && <1.5
+    , generic-random ==1.5.*
     , http-types ==0.12.*
     , http2 ==4.1.*
     , ini ==0.4.1
     , iproute ==1.7.*
     , iso8601-time ==0.1.*
-    , memory ==0.15.*
+    , memory ==0.18.*
     , mtl ==2.2.*
     , network >=3.1.2.7 && <3.2
-    , network-transport ==0.5.4
+    , network-transport ==0.5.6
     , optparse-applicative >=0.15 && <0.17
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -436,9 +436,9 @@ executable xftp
     , socks ==0.6.*
     , sqlcipher-simple ==0.4.*
     , stm ==2.5.*
-    , template-haskell ==2.16.*
+    , template-haskell ==2.19.*
     , temporary ==1.3.*
-    , text ==1.2.*
+    , text ==2.0.*
     , time ==1.9.*
     , time-compat ==1.9.*
     , time-manager ==0.0.*
@@ -464,7 +464,7 @@ executable xftp-server
   ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
   build-depends:
       QuickCheck ==2.14.*
-    , aeson ==2.0.*
+    , aeson ==2.1.*
     , ansi-terminal >=0.10 && <0.12
     , asn1-encoding ==0.9.*
     , asn1-types ==0.3.*
@@ -472,27 +472,27 @@ executable xftp-server
     , attoparsec ==0.14.*
     , base >=4.14 && <5
     , base64-bytestring >=1.0 && <1.3
-    , bytestring ==0.10.*
+    , bytestring ==0.11.*
     , case-insensitive ==1.2.*
     , composition ==1.0.*
     , constraints >=0.12 && <0.14
     , containers ==0.6.*
-    , cryptonite >=0.27 && <0.30
+    , cryptonite >=0.30
     , cryptostore ==0.2.*
     , data-default ==0.7.*
     , direct-sqlcipher ==2.3.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , generic-random >=1.3 && <1.5
+    , generic-random ==1.5.*
     , http-types ==0.12.*
     , http2 ==4.1.*
     , ini ==0.4.1
     , iproute ==1.7.*
     , iso8601-time ==0.1.*
-    , memory ==0.15.*
+    , memory ==0.18.*
     , mtl ==2.2.*
     , network >=3.1.2.7 && <3.2
-    , network-transport ==0.5.4
+    , network-transport ==0.5.6
     , optparse-applicative >=0.15 && <0.17
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -501,9 +501,9 @@ executable xftp-server
     , socks ==0.6.*
     , sqlcipher-simple ==0.4.*
     , stm ==2.5.*
-    , template-haskell ==2.16.*
+    , template-haskell ==2.19.*
     , temporary ==1.3.*
-    , text ==1.2.*
+    , text ==2.0.*
     , time ==1.9.*
     , time-compat ==1.9.*
     , time-manager ==0.0.*
@@ -556,7 +556,7 @@ test-suite simplexmq-test
   build-depends:
       HUnit ==1.6.*
     , QuickCheck ==2.14.*
-    , aeson ==2.0.*
+    , aeson ==2.1.*
     , ansi-terminal >=0.10 && <0.12
     , asn1-encoding ==0.9.*
     , asn1-types ==0.3.*
@@ -564,19 +564,19 @@ test-suite simplexmq-test
     , attoparsec ==0.14.*
     , base >=4.14 && <5
     , base64-bytestring >=1.0 && <1.3
-    , bytestring ==0.10.*
+    , bytestring ==0.11.*
     , case-insensitive ==1.2.*
     , composition ==1.0.*
     , constraints >=0.12 && <0.14
     , containers ==0.6.*
-    , cryptonite >=0.27 && <0.30
+    , cryptonite >=0.30
     , cryptostore ==0.2.*
     , data-default ==0.7.*
     , deepseq ==1.4.*
     , direct-sqlcipher ==2.3.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , generic-random >=1.3 && <1.5
+    , generic-random ==1.5.*
     , hspec ==2.7.*
     , hspec-core ==2.7.*
     , http-types ==0.12.*
@@ -585,10 +585,10 @@ test-suite simplexmq-test
     , iproute ==1.7.*
     , iso8601-time ==0.1.*
     , main-tester ==0.2.*
-    , memory ==0.15.*
+    , memory ==0.18.*
     , mtl ==2.2.*
     , network >=3.1.2.7 && <3.2
-    , network-transport ==0.5.4
+    , network-transport ==0.5.6
     , optparse-applicative >=0.15 && <0.17
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -598,9 +598,9 @@ test-suite simplexmq-test
     , socks ==0.6.*
     , sqlcipher-simple ==0.4.*
     , stm ==2.5.*
-    , template-haskell ==2.16.*
+    , template-haskell ==2.19.*
     , temporary ==1.3.*
-    , text ==1.2.*
+    , text ==2.0.*
     , time ==1.9.*
     , time-compat ==1.9.*
     , time-manager ==0.0.*


### PR DESCRIPTION
I found a working package set, and could update the `stack.yaml` to reflect these new packages.

One issue is that GHC 9.4.1 and greater requires that you disambiguate duplicate record fields (see bottom of [docs here](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/disambiguate_record_fields.html#disambiguate-fields))

I started disambiguating record fields by hand, but it was pretty invasive and manual. I was wondering if you would be open to turning on `-WAmbiguous-fields` and then I could work on slowly disambiguating them in several prs before coming back to this one.