### PR TITLE
server: add control port commands for clients and ghc threads

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -97,6 +97,7 @@ executables:
       - simplexmq
     ghc-options:
       - -threaded
+      - -rtsopts
 
   ntf-server:
     source-dirs: apps/ntf-server
@@ -105,6 +106,7 @@ executables:
       - simplexmq
     ghc-options:
       - -threaded
+      - -rtsopts
 
   xftp-server:
     source-dirs: apps/xftp-server
@@ -113,6 +115,7 @@ executables:
       - simplexmq
     ghc-options:
       - -threaded
+      - -rtsopts
 
   smp-agent:
     source-dirs: apps/smp-agent
@@ -121,6 +124,7 @@ executables:
       - simplexmq
     ghc-options:
       - -threaded
+      - -rtsopts
 
   xftp:
     source-dirs: apps/xftp
@@ -129,6 +133,7 @@ executables:
       - simplexmq
     ghc-options:
       - -threaded
+      - -rtsopts
 
 tests:
   simplexmq-test:

--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -203,7 +203,7 @@ executable ntf-server
       Paths_simplexmq
   hs-source-dirs:
       apps/ntf-server
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded -rtsopts
   build-depends:
       QuickCheck ==2.14.*
     , aeson ==2.2.*
@@ -268,7 +268,7 @@ executable smp-agent
       Paths_simplexmq
   hs-source-dirs:
       apps/smp-agent
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded -rtsopts
   build-depends:
       QuickCheck ==2.14.*
     , aeson ==2.2.*
@@ -333,7 +333,7 @@ executable smp-server
       Paths_simplexmq
   hs-source-dirs:
       apps/smp-server
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded -rtsopts
   build-depends:
       QuickCheck ==2.14.*
     , aeson ==2.2.*
@@ -398,7 +398,7 @@ executable xftp
       Paths_simplexmq
   hs-source-dirs:
       apps/xftp
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded -rtsopts
   build-depends:
       QuickCheck ==2.14.*
     , aeson ==2.2.*
@@ -463,7 +463,7 @@ executable xftp-server
       Paths_simplexmq
   hs-source-dirs:
       apps/xftp-server
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wunused-type-patterns -threaded -rtsopts
   build-depends:
       QuickCheck ==2.14.*
     , aeson ==2.2.*

--- a/src/Simplex/Messaging/Server.hs
+++ b/src/Simplex/Messaging/Server.hs
@@ -285,6 +285,7 @@ smpServer started cfg@ServerConfig {transports, transportConfig = tCfg} = do
                 hPutStrLn h "server state saved!"
               CPHelp -> hPutStrLn h "commands: stats, save, help, quit"
               CPQuit -> pure ()
+              CPSkip -> pure ()
 
 runClientTransport :: Transport c => THandle c -> M ()
 runClientTransport th@THandle {thVersion, sessionId} = do

--- a/src/Simplex/Messaging/Server.hs
+++ b/src/Simplex/Messaging/Server.hs
@@ -59,6 +59,7 @@ import Data.Time.Clock (UTCTime (..), diffTimeToPicoseconds, getCurrentTime)
 import Data.Time.Clock.System (SystemTime (..), getSystemTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Data.Type.Equality
+import GHC.Stats (getRTSStats)
 import GHC.TypeLits (KnownNat)
 import Network.Socket (ServiceName, Socket, socketToHandle)
 import Simplex.Messaging.Agent.Lock
@@ -275,6 +276,9 @@ smpServer started cfg@ServerConfig {transports, transportConfig = tCfg} = do
                 where
                   putStat :: Show a => String -> TVar a -> IO ()
                   putStat label var = readTVarIO var >>= \v -> hPutStrLn h $ label <> ": " <> show v
+              CPStatsRTS -> do
+                rts <- getRTSStats
+                hPutStrLn h $ show rts
               CPSave -> withLock (savingLock srv) "control" $ do
                 hPutStrLn h "saving server state..."
                 unliftIO u $ saveServer True

--- a/src/Simplex/Messaging/Server/Control.hs
+++ b/src/Simplex/Messaging/Server/Control.hs
@@ -15,6 +15,7 @@ data ControlProtocol
   | CPSave
   | CPHelp
   | CPQuit
+  | CPSkip
 
 instance StrEncoding ControlProtocol where
   strEncode = \case
@@ -26,6 +27,7 @@ instance StrEncoding ControlProtocol where
     CPSave -> "save"
     CPHelp -> "help"
     CPQuit -> "quit"
+    CPSkip -> ""
   strP =
     A.takeTill (== ' ') >>= \case
       "suspend" -> pure CPSuspend
@@ -36,4 +38,5 @@ instance StrEncoding ControlProtocol where
       "save" -> pure CPSave
       "help" -> pure CPHelp
       "quit" -> pure CPQuit
+      "" -> pure CPSkip
       _ -> fail "bad ControlProtocol command"

--- a/src/Simplex/Messaging/Server/Control.hs
+++ b/src/Simplex/Messaging/Server/Control.hs
@@ -12,6 +12,7 @@ data ControlProtocol
   | CPClients
   | CPStats
   | CPStatsRTS
+  | CPThreads
   | CPSave
   | CPHelp
   | CPQuit
@@ -24,6 +25,7 @@ instance StrEncoding ControlProtocol where
     CPClients -> "clients"
     CPStats -> "stats"
     CPStatsRTS -> "stats-rts"
+    CPThreads -> "threads"
     CPSave -> "save"
     CPHelp -> "help"
     CPQuit -> "quit"
@@ -35,6 +37,7 @@ instance StrEncoding ControlProtocol where
       "clients" -> pure CPClients
       "stats" -> pure CPStats
       "stats-rts" -> pure CPStatsRTS
+      "threads" -> pure CPThreads
       "save" -> pure CPSave
       "help" -> pure CPHelp
       "quit" -> pure CPQuit

--- a/src/Simplex/Messaging/Server/Control.hs
+++ b/src/Simplex/Messaging/Server/Control.hs
@@ -11,6 +11,7 @@ data ControlProtocol
   | CPResume
   | CPClients
   | CPStats
+  | CPStatsRTS
   | CPSave
   | CPHelp
   | CPQuit
@@ -21,6 +22,7 @@ instance StrEncoding ControlProtocol where
     CPResume -> "resume"
     CPClients -> "clients"
     CPStats -> "stats"
+    CPStatsRTS -> "stats-rts"
     CPSave -> "save"
     CPHelp -> "help"
     CPQuit -> "quit"
@@ -30,6 +32,7 @@ instance StrEncoding ControlProtocol where
       "resume" -> pure CPResume
       "clients" -> pure CPClients
       "stats" -> pure CPStats
+      "stats-rts" -> pure CPStatsRTS
       "save" -> pure CPSave
       "help" -> pure CPHelp
       "quit" -> pure CPQuit

--- a/src/Simplex/Messaging/Transport/Server.hs
+++ b/src/Simplex/Messaging/Transport/Server.hs
@@ -32,7 +32,7 @@ import qualified Network.TLS as T
 import Simplex.Messaging.TMap (TMap)
 import qualified Simplex.Messaging.TMap as TM
 import Simplex.Messaging.Transport
-import Simplex.Messaging.Util (catchAll_, tshow)
+import Simplex.Messaging.Util (catchAll_, labelMyThread, tshow)
 import System.Exit (exitFailure)
 import System.Mem.Weak (Weak, deRefWeak)
 import UnliftIO.Concurrent
@@ -63,6 +63,7 @@ runTransportServer :: forall c m. (Transport c, MonadUnliftIO m) => TMVar Bool -
 runTransportServer started port serverParams cfg server = do
   u <- askUnliftIO
   let tCfg = serverTransportConfig cfg
+  labelMyThread $ "transport server for " <> transportName (TProxy :: TProxy c)
   liftIO . runTCPServer started port $ \conn ->
     E.bracket
       (connectTLS Nothing tCfg serverParams conn >>= getServerConnection tCfg)

--- a/src/Simplex/Messaging/Util.hs
+++ b/src/Simplex/Messaging/Util.hs
@@ -160,7 +160,5 @@ showHexBytes = foldr toHex0 "" . BW.unpack
     | n < 0x10 = ('0' :) . showHex n
     | otherwise = showHex n
 
-labelMyThread :: (MonadIO m) => String -> m ()
-labelMyThread label =
-  liftIO $ myThreadId >>= \tid ->
-    labelThread tid label
+labelMyThread :: MonadIO m => String -> m ()
+labelMyThread label = liftIO $ myThreadId >>= (`labelThread` label)

--- a/src/Simplex/Messaging/Util.hs
+++ b/src/Simplex/Messaging/Util.hs
@@ -9,6 +9,7 @@ import Control.Monad
 import Control.Monad.Except
 import Control.Monad.IO.Unlift
 import Data.Bifunctor (first)
+import qualified Data.ByteString as BW
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as B
 import Data.Int (Int64)
@@ -19,6 +20,8 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Time (NominalDiffTime)
+import GHC.Conc
+import Numeric (showHex)
 import UnliftIO.Async
 import qualified UnliftIO.Exception as UE
 
@@ -149,3 +152,15 @@ diffToMicroseconds diff = fromIntegral ((truncate $ diff * 1000000) :: Integer)
 
 diffToMilliseconds :: NominalDiffTime -> Int64
 diffToMilliseconds diff = fromIntegral ((truncate $ diff * 1000) :: Integer)
+
+showHexBytes :: ByteString -> String
+showHexBytes = foldr toHex0 "" . BW.unpack
+ where
+  toHex0 n
+    | n < 0x10 = ('0' :) . showHex n
+    | otherwise = showHex n
+
+labelMyThread :: (MonadIO m) => String -> m ()
+labelMyThread label =
+  liftIO $ myThreadId >>= \tid ->
+    labelThread tid label


### PR DESCRIPTION
`threads`:
```
Threads: 20
ThreadId 2 (ThreadRunning) IOManager on cap 0
ThreadId 3 (ThreadBlocked BlockedOnForeignCall) TimerManager
ThreadId 4 (ThreadBlocked BlockedOnSTM) 
ThreadId 5 (ThreadBlocked BlockedOnMVar) 
ThreadId 6 (ThreadBlocked BlockedOnMVar) 
ThreadId 9 (ThreadBlocked BlockedOnSTM) server subscribedQ
ThreadId 10 (ThreadBlocked BlockedOnSTM) server ntfSubscribedQ
ThreadId 11 (ThreadBlocked BlockedOnMVar) transport server for TLS
ThreadId 12 (ThreadBlocked BlockedOnMVar) expireMessages
ThreadId 13 (ThreadBlocked BlockedOnMVar) logServerStats
ThreadId 14 (ThreadBlocked BlockedOnMVar) control port server
ThreadId 16 (ThreadRunning) control port client
ThreadId 17 (ThreadBlocked BlockedOnSTM) smp client $b2cdc6899d2d3563227be17fdd0541d83fda38441474c1a084302b486c9ce5
ThreadId 19 (ThreadBlocked BlockedOnSTM) smp client $b2cdc6899d2d3563227be17fdd0541d83fda38441474c1a084302b486c9ce5 send
ThreadId 20 (ThreadBlocked BlockedOnSTM) 
ThreadId 21 (ThreadBlocked BlockedOnMVar) 
ThreadId 22 (ThreadBlocked BlockedOnSTM) 
ThreadId 23 (ThreadBlocked BlockedOnSTM) 
ThreadId 24 (ThreadBlocked BlockedOnSTM) 
ThreadId 25 (ThreadBlocked BlockedOnSTM) 
```
Some threads are missing labels as this is WIP.

----

`clients`:
```
Clients: 4
Client 19bfab999985a541d8a6c8653e716741e87cb7db69a311f
  session: b2cdc6899d2d3563227be17fdd0541d83fda38441474c1a084302b486c9ce5
  connected: True
  activeAt: 1692973231
  subscriptions: 4
Client 89b0f0bf2ff57709e16282f2b9a24ea3b8c6cf12783de4a
  session: b2cdc6899d2d3563227be17fdd0541d83fda38441474c1a084302b486c9ce5
  connected: True
  activeAt: 1692973231
  subscriptions: 4
Client 9ed1a83e5479dc54aa33c2d5739d5ceeb4d45ae51036522
  session: b2cdc6899d2d3563227be17fdd0541d83fda38441474c1a084302b486c9ce5
  connected: True
  activeAt: 1692973231
  subscriptions: 4
Client d7014852698725ec2ff47ed7f17abbb73bfabfd57e665
  session: b2cdc6899d2d3563227be17fdd0541d83fda38441474c1a084302b486c9ce5
  connected: True
  activeAt: 1692973231
  subscriptions: 4
```
Less obviously useful, can be dropped for now.