### PR TITLE
core: use explicit NonEmpty encoding for TBTransmissions

### DIFF
--- a/src/Simplex/Messaging/Protocol.hs
+++ b/src/Simplex/Messaging/Protocol.hs
@@ -1359,9 +1359,9 @@ batchTransmissions' batch bSize
           sLen = B.length s
           len' = len + sLen
     addBatch :: ([TransportBatch r], Int, Int, [ByteString], [r]) -> [TransportBatch r]
-    addBatch (bs, _len, n, ss, rs) = if n == 0 then bs else TBTransmissions b n rs : bs
-      where
-        b = B.concat $ B.singleton (lenEncode n) : ss
+    addBatch (bs, _len, n, c : cs, rs) = TBTransmissions (smpEncode $ Tail c :| map Tail cs) n rs : bs
+    addBatch (bs, _len, 0, [], []) = bs
+    addBatch (bs, _len, _, _, _) = bs -- should not happen: no chunks collected, however some elements got stored anyway
 
 tEncode :: SentRawTransmission -> ByteString
 tEncode (auth, t) = smpEncode (tAuthBytes auth) <> t


### PR DESCRIPTION
Batched item can be decoded as `Encoding a => NonEmpty a` (with the raw form `a ~ Tail ByteString`), but this fact can only be guessed.