### PR TITLE
actions: ignore uploading GHC 8.10.7 binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           mv $(cabal list-bin xftp) xftp-ubuntu-${{ matrix.platform_name}}
 
       - name: Build changelog
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'ubuntu-20.04'
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'ubuntu-22.04'
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v1
         with:
@@ -75,7 +75,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'ubuntu-20.04' && matrix.ghc == '9.6.3'
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.ghc != '8.10.7'
         uses: softprops/action-gh-release@v1
         with:
           body: |


### PR DESCRIPTION
In other words, finally upload 22.04 binaries.

Binaries compiled with correct GHC: 
```sh
❯ ls
Permissions Size User Date Modified Name
.rw-r--r--   59M sh   22 Mar 13:38   ntf-server-ubuntu-20_04-x86-64
.rw-r--r--   59M sh   22 Mar 13:36   ntf-server-ubuntu-22_04-x86-64
.rw-r--r--   48M sh   22 Mar 13:38   smp-server-ubuntu-20_04-x86-64
.rw-r--r--   48M sh   22 Mar 13:36   smp-server-ubuntu-22_04-x86-64
.rw-r--r--   53M sh   22 Mar 13:38   xftp-server-ubuntu-20_04-x86-64
.rw-r--r--   54M sh   22 Mar 13:37   xftp-server-ubuntu-22_04-x86-64
❯ strings *-server-ubuntu* | grep 'GHC 9'
GHC 9.6.3
GHC 9.6.3
GHC 9.6.3
GHC 9.6.3
GHC 9.6.3
GHC 9.6.3
```

Test repo: [generated release](https://github.com/shumvgolove/simplexmq/releases/tag/v7.0.0) and [executed actions](https://github.com/shumvgolove/simplexmq/actions/runs/8390822110).