### PR TITLE
server: preprocess proxy commands that will not be connecting to network to reduce concurrency, do not wait for destination relay responses before processing the next command

### DIFF
--- a/src/Simplex/Messaging/Server.hs
+++ b/src/Simplex/Messaging/Server.hs
@@ -59,7 +59,7 @@ import Data.List (intercalate, mapAccumR)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as L
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, isNothing)
+import Data.Maybe (catMaybes, fromMaybe, isNothing)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeLatin1)
 import Data.Time.Clock (UTCTime (..), diffTimeToPicoseconds, getCurrentTime)
@@ -103,7 +103,6 @@ import UnliftIO.IO
 import UnliftIO.STM
 #if MIN_VERSION_base(4,18,0)
 import Data.List (sort)
-import Data.Maybe (fromMaybe)
 import GHC.Conc (listThreads, threadStatus)
 import GHC.Conc.Sync (threadLabel)
 #endif

--- a/src/Simplex/Messaging/Server.hs
+++ b/src/Simplex/Messaging/Server.hs
@@ -679,12 +679,12 @@ client thParams' clnt@Client {subscriptions, ntfSubscriptions, rcvQ, sndQ, sessi
         signal = atomically $ modifyTVar' procThreads (\t -> t - 1)
     processProxiedCmd :: Transmission (Command 'ProxiedClient) -> M (Either (M (Transmission BrokerMsg)) (Transmission BrokerMsg))
     processProxiedCmd (corrId, sessId, command) = (corrId,sessId,) <$$> case command of
-      PRXY srv auth -> ifM allowProxy getConnectedRelay (pure $ Right $ ERR $ PROXY BASIC_AUTH)
+      PRXY srv auth -> ifM allowProxy getRelay (pure $ Right $ ERR $ PROXY BASIC_AUTH)
         where
           allowProxy = do
             ServerConfig {allowSMPProxy, newQueueBasicAuth} <- asks config
             pure $ allowSMPProxy && maybe True ((== auth) . Just) newQueueBasicAuth
-          getConnectedRelay = do
+          getRelay = do
             ProxyAgent {smpAgent = a} <- asks proxyAgent
             liftIO (getConnectedSMPServerClient a srv) >>= \case
               Just r -> Right <$> proxyServerResponse a r

--- a/src/Simplex/Messaging/Server/Env/STM.hs
+++ b/src/Simplex/Messaging/Server/Env/STM.hs
@@ -104,7 +104,7 @@ defaultInactiveClientExpiration =
     }
 
 defaultProxyClientConcurrency :: Int
-defaultProxyClientConcurrency = 16
+defaultProxyClientConcurrency = 32
 
 data Env = Env
   { config :: ServerConfig,

--- a/tests/AgentTests/EqInstances.hs
+++ b/tests/AgentTests/EqInstances.hs
@@ -6,6 +6,7 @@ module AgentTests.EqInstances where
 
 import Data.Type.Equality
 import Simplex.Messaging.Agent.Store
+import Simplex.Messaging.Client (ProxiedRelay (..))
 
 instance Eq SomeConn where
   SomeConn d c == SomeConn d' c' = case testEquality d d' of
@@ -23,3 +24,7 @@ deriving instance Eq (StoredSndQueue q)
 deriving instance Eq (DBQueueId q)
 
 deriving instance Eq ClientNtfCreds
+
+deriving instance Show ProxiedRelay
+
+deriving instance Eq ProxiedRelay

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -60,7 +60,7 @@ main = do
         describe "SMP server via WebSockets" $ serverTests (transport @WS)
         describe "Notifications server" $ ntfServerTests (transport @TLS)
         describe "SMP client agent" $ agentTests (transport @TLS)
-        describe "SMP proxy" smpProxyTests
+        fdescribe "SMP proxy" smpProxyTests
         describe "XFTP" $ do
           describe "XFTP server" xftpServerTests
           describe "XFTP file description" fileDescriptionTests

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -60,7 +60,7 @@ main = do
         describe "SMP server via WebSockets" $ serverTests (transport @WS)
         describe "Notifications server" $ ntfServerTests (transport @TLS)
         describe "SMP client agent" $ agentTests (transport @TLS)
-        fdescribe "SMP proxy" smpProxyTests
+        describe "SMP proxy" smpProxyTests
         describe "XFTP" $ do
           describe "XFTP server" xftpServerTests
           describe "XFTP file description" fileDescriptionTests


### PR DESCRIPTION
- do not block client session while waiting for response from destination relay, only block when exceeding concurrency limit (which is increased).
- some responses are made synchronously without forking threads. 

The current implementation of proxy was blocking client session not only when exceeding concurrency quota, but also while waiting for response from the destination relay.