### PR TITLE
smp server: do not cache all queues from database while processing expirations

### DIFF
--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -228,6 +228,7 @@ library
           Simplex.Messaging.Server.Main
           Simplex.Messaging.Server.MsgStore
           Simplex.Messaging.Server.MsgStore.Journal
+          Simplex.Messaging.Server.MsgStore.Journal.Lock
           Simplex.Messaging.Server.MsgStore.STM
           Simplex.Messaging.Server.MsgStore.Types
           Simplex.Messaging.Server.NtfStore

--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           simplexmq
-version:        6.3.0.803
+version:        6.3.0.8
 synopsis:       SimpleXMQ message broker
 description:    This package includes <./docs/Simplex-Messaging-Server.html server>,
                 <./docs/Simplex-Messaging-Client.html client> and

--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -228,7 +228,7 @@ library
           Simplex.Messaging.Server.Main
           Simplex.Messaging.Server.MsgStore
           Simplex.Messaging.Server.MsgStore.Journal
-          Simplex.Messaging.Server.MsgStore.Journal.Lock
+          Simplex.Messaging.Server.MsgStore.Journal.SharedLock
           Simplex.Messaging.Server.MsgStore.STM
           Simplex.Messaging.Server.MsgStore.Types
           Simplex.Messaging.Server.NtfStore

--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           simplexmq
-version:        6.3.0.802
+version:        6.3.0.803
 synopsis:       SimpleXMQ message broker
 description:    This package includes <./docs/Simplex-Messaging-Server.html server>,
                 <./docs/Simplex-Messaging-Client.html client> and

--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           simplexmq
-version:        6.3.0.8
+version:        6.3.0.803
 synopsis:       SimpleXMQ message broker
 description:    This package includes <./docs/Simplex-Messaging-Server.html server>,
                 <./docs/Simplex-Messaging-Client.html client> and

--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           simplexmq
-version:        6.3.0.803
+version:        6.3.0.804
 synopsis:       SimpleXMQ message broker
 description:    This package includes <./docs/Simplex-Messaging-Server.html server>,
                 <./docs/Simplex-Messaging-Client.html client> and

--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           simplexmq
-version:        6.3.0.804
+version:        6.3.0.8
 synopsis:       SimpleXMQ message broker
 description:    This package includes <./docs/Simplex-Messaging-Server.html server>,
                 <./docs/Simplex-Messaging-Client.html client> and

--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           simplexmq
-version:        6.3.0.8
+version:        6.3.0.802
 synopsis:       SimpleXMQ message broker
 description:    This package includes <./docs/Simplex-Messaging-Server.html server>,
                 <./docs/Simplex-Messaging-Client.html client> and

--- a/src/Simplex/Messaging/Agent/Lock.hs
+++ b/src/Simplex/Messaging/Agent/Lock.hs
@@ -6,6 +6,7 @@ module Simplex.Messaging.Agent.Lock
     withLock',
     withGetLock,
     withGetLocks,
+    getPutLock,
   )
 where
 

--- a/src/Simplex/Messaging/Server.hs
+++ b/src/Simplex/Messaging/Server.hs
@@ -404,7 +404,7 @@ smpServer started cfg@ServerConfig {transports, transportConfig = tCfg, startOpt
           old <- expireBeforeEpoch expCfg
           now <- systemSeconds <$> getSystemTime
           msgStats@MessageStats {storedMsgsCount = stored, expiredMsgsCount = expired} <-
-            withAllMsgQueues False ms $ expireQueueMsgs now ms old
+            withActiveMsgQueues ms $ expireQueueMsgs now ms old
           atomicWriteIORef (msgCount stats) stored
           atomicModifyIORef'_ (msgExpired stats) (+ expired)
           printMessageStats "STORE: messages" msgStats

--- a/src/Simplex/Messaging/Server.hs
+++ b/src/Simplex/Messaging/Server.hs
@@ -398,7 +398,8 @@ smpServer started cfg@ServerConfig {transports, transportConfig = tCfg, startOpt
       where
         expire :: forall s. MsgStoreClass s => s -> ServerStats -> Int64 -> IO ()
         expire ms stats interval = do
-          threadDelay' interval
+          threadDelay' 10000000
+          logInfo "expiring"
           n <- compactQueues @(StoreQueue s) $ queueStore ms
           when (n > 0) $ logInfo $ "Removed " <> tshow n <> " old deleted queues from the database."
           old <- expireBeforeEpoch expCfg
@@ -408,6 +409,7 @@ smpServer started cfg@ServerConfig {transports, transportConfig = tCfg, startOpt
           atomicWriteIORef (msgCount stats) stored
           atomicModifyIORef'_ (msgExpired stats) (+ expired)
           printMessageStats "STORE: messages" msgStats
+          threadDelay' interval
         expireQueueMsgs now ms old q = do
           (expired_, stored) <- idleDeleteExpiredMsgs now ms q old
           pure MessageStats {storedMsgsCount = stored, expiredMsgsCount = fromMaybe 0 expired_, storedQueues = 1}

--- a/src/Simplex/Messaging/Server.hs
+++ b/src/Simplex/Messaging/Server.hs
@@ -404,7 +404,7 @@ smpServer started cfg@ServerConfig {transports, transportConfig = tCfg, startOpt
           old <- expireBeforeEpoch expCfg
           now <- systemSeconds <$> getSystemTime
           msgStats@MessageStats {storedMsgsCount = stored, expiredMsgsCount = expired} <-
-            withActiveMsgQueues ms $ expireQueueMsgs now ms old
+            withAllMsgQueues False ms $ expireQueueMsgs now ms old
           atomicWriteIORef (msgCount stats) stored
           atomicModifyIORef'_ (msgExpired stats) (+ expired)
           printMessageStats "STORE: messages" msgStats

--- a/src/Simplex/Messaging/Server.hs
+++ b/src/Simplex/Messaging/Server.hs
@@ -398,8 +398,7 @@ smpServer started cfg@ServerConfig {transports, transportConfig = tCfg, startOpt
       where
         expire :: forall s. MsgStoreClass s => s -> ServerStats -> Int64 -> IO ()
         expire ms stats interval = do
-          threadDelay' 10000000
-          logInfo "expiring"
+          threadDelay' interval
           n <- compactQueues @(StoreQueue s) $ queueStore ms
           when (n > 0) $ logInfo $ "Removed " <> tshow n <> " old deleted queues from the database."
           old <- expireBeforeEpoch expCfg
@@ -409,7 +408,6 @@ smpServer started cfg@ServerConfig {transports, transportConfig = tCfg, startOpt
           atomicWriteIORef (msgCount stats) stored
           atomicModifyIORef'_ (msgExpired stats) (+ expired)
           printMessageStats "STORE: messages" msgStats
-          threadDelay' interval
         expireQueueMsgs now ms old q = do
           (expired_, stored) <- idleDeleteExpiredMsgs now ms q old
           pure MessageStats {storedMsgsCount = stored, expiredMsgsCount = fromMaybe 0 expired_, storedQueues = 1}

--- a/src/Simplex/Messaging/Server/MsgStore/Journal.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/Journal.hs
@@ -376,9 +376,8 @@ instance MsgStoreClass (JournalMsgStore s) where
           queueState
         }
 
-  getCachedQueue :: JournalMsgStore s -> JournalQueue s -> StoreIO s (Maybe (JournalQueue s))
-  getCachedQueue ms sq = StoreIO $ TM.lookupIO (recipientId sq) (loadedQueues $ queueStore_ ms)
-  {-# INLINE getCachedQueue #-}
+  getLoadedQueue :: JournalMsgStore s -> JournalQueue s -> StoreIO s (JournalQueue s)
+  getLoadedQueue ms sq = StoreIO $ fromMaybe sq <$> TM.lookupIO (recipientId sq) (loadedQueues $ queueStore_ ms)
 
   getMsgQueue :: JournalMsgStore s -> JournalQueue s -> Bool -> StoreIO s (JournalMsgQueue s)
   getMsgQueue ms@JournalMsgStore {random} q'@JournalQueue {recipientId' = rId, msgQueue'} forWrite =

--- a/src/Simplex/Messaging/Server/MsgStore/Journal.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/Journal.hs
@@ -70,7 +70,7 @@ import Simplex.Messaging.Agent.Client (getMapLock)
 import Simplex.Messaging.Agent.Lock
 import Simplex.Messaging.Encoding.String
 import Simplex.Messaging.Protocol
-import Simplex.Messaging.Server.MsgStore.Journal.Lock
+import Simplex.Messaging.Server.MsgStore.Journal.SharedLock
 import Simplex.Messaging.Server.MsgStore.Types
 import Simplex.Messaging.Server.QueueStore
 import Simplex.Messaging.Server.QueueStore.Postgres
@@ -368,7 +368,7 @@ instance MsgStoreClass (JournalMsgStore s) where
     PQStore st ->
       foldQueueRecs tty st $ \(rId, qr) -> do
         q <- mkQueue ms rId qr
-        withSharedLock rId queueLocks sharedLock $
+        withSharedWaitLock rId queueLocks sharedLock $
           run $ tryStore' op rId $ unStoreIO $ action q
     where
       run :: ExceptT ErrorType IO a -> IO a

--- a/src/Simplex/Messaging/Server/MsgStore/Journal/Lock.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/Journal/Lock.hs
@@ -1,0 +1,35 @@
+module Simplex.Messaging.Server.MsgStore.Journal.Lock where
+
+import Control.Concurrent.STM
+import qualified Control.Exception as E
+import Control.Monad
+import Simplex.Messaging.Agent.Lock
+import Simplex.Messaging.Agent.Client (getMapLock)
+import Simplex.Messaging.Protocol (RecipientId)
+import Simplex.Messaging.TMap (TMap)
+import qualified Simplex.Messaging.TMap as TM
+import Simplex.Messaging.Util (($>>), ($>>=))
+
+withLockAndShared :: RecipientId -> Lock -> TVar (Maybe RecipientId) -> String -> IO a -> IO a
+withLockAndShared rId lock shared name =
+  E.bracket_
+    (atomically $ retrySharedLocked rId shared >> putTMVar lock name)
+    (void $ atomically $ takeTMVar lock)
+
+withLockMapAndShared :: RecipientId -> TMap RecipientId Lock -> TVar (Maybe RecipientId) -> String -> IO a -> IO a
+withLockMapAndShared rId locks shared name a =
+  E.bracket
+    (atomically $ retrySharedLocked rId shared >> getPutLock (getMapLock locks) rId name)
+    (atomically . takeTMVar)
+    (const a)
+
+retrySharedLocked :: RecipientId -> TVar (Maybe RecipientId) -> STM ()
+retrySharedLocked rId shared = readTVar shared >>= mapM_ (\rId' -> when (rId == rId') retry)
+
+withSharedLock :: RecipientId -> TMap RecipientId Lock -> TVar (Maybe RecipientId) -> String -> IO a -> IO a
+withSharedLock rId locks shared name =
+  E.bracket_
+    (atomically $ retryLocked >> writeTVar shared (Just rId))
+    (atomically $ writeTVar shared Nothing)
+  where
+    retryLocked = TM.lookup rId locks $>>= tryReadTMVar $>> retry

--- a/src/Simplex/Messaging/Server/MsgStore/Journal/SharedLock.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/Journal/SharedLock.hs
@@ -1,4 +1,9 @@
-module Simplex.Messaging.Server.MsgStore.Journal.Lock where
+module Simplex.Messaging.Server.MsgStore.Journal.SharedLock
+  ( withLockWaitShared,
+    withLockMapWaitShared,
+    withSharedWaitLock,
+  )
+where
 
 import Control.Concurrent.STM
 import qualified Control.Exception as E
@@ -29,8 +34,8 @@ waitShared :: RecipientId -> TMVar RecipientId -> STM ()
 waitShared rId shared = tryReadTMVar shared >>= mapM_ (\rId' -> when (rId == rId') retry)
 
 -- wait until lock with passed ID in Map is released and take shared lock for this ID
-withSharedLock :: RecipientId -> TMap RecipientId Lock -> TMVar RecipientId -> IO a -> IO a
-withSharedLock rId locks shared =
+withSharedWaitLock :: RecipientId -> TMap RecipientId Lock -> TMVar RecipientId -> IO a -> IO a
+withSharedWaitLock rId locks shared =
   E.bracket_
     (atomically $ waitLock >> putTMVar shared rId)
     (atomically $ takeTMVar shared)

--- a/src/Simplex/Messaging/Server/MsgStore/STM.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/STM.hs
@@ -80,7 +80,9 @@ instance MsgStoreClass STMMsgStore where
   {-# INLINE closeMsgStore #-}
   withActiveMsgQueues = withLoadedQueues . queueStore_
   {-# INLINE withActiveMsgQueues #-}
-  withAllMsgQueues _ = withLoadedQueues . queueStore_
+  unsafeWithAllMsgQueues _ = withLoadedQueues . queueStore_
+  {-# INLINE unsafeWithAllMsgQueues #-}
+  withAllMsgQueues _tty _op ms action = withLoadedQueues (queueStore_ ms) $ atomically . action
   {-# INLINE withAllMsgQueues #-}
   logQueueStates _ = pure ()
   {-# INLINE logQueueStates #-}
@@ -172,3 +174,8 @@ instance MsgStoreClass STMMsgStore where
 
   isolateQueue :: STMQueue -> String -> STM a -> ExceptT ErrorType IO a
   isolateQueue _ _ = liftIO . atomically
+  {-# INLINE isolateQueue #-}
+
+  unsafeRunStore :: STMQueue -> String -> STM a -> IO a
+  unsafeRunStore _ _ = atomically
+  {-# INLINE unsafeRunStore #-}

--- a/src/Simplex/Messaging/Server/MsgStore/STM.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/STM.hs
@@ -92,9 +92,9 @@ instance MsgStoreClass STMMsgStore where
   mkQueue _ rId qr = STMQueue rId <$> newTVarIO (Just qr) <*> newTVarIO Nothing
   {-# INLINE mkQueue #-}
 
-  getCachedQueue :: STMMsgStore -> STMQueue -> STM (Maybe STMQueue)
-  getCachedQueue _ = pure . Just
-  {-# INLINE getCachedQueue #-}
+  getLoadedQueue :: STMMsgStore -> STMQueue -> STM STMQueue
+  getLoadedQueue _ = pure
+  {-# INLINE getLoadedQueue #-}
 
   getMsgQueue :: STMMsgStore -> STMQueue -> Bool -> STM STMMsgQueue
   getMsgQueue _ STMQueue {msgQueue'} _ = readTVar msgQueue' >>= maybe newQ pure

--- a/src/Simplex/Messaging/Server/MsgStore/STM.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/STM.hs
@@ -92,6 +92,10 @@ instance MsgStoreClass STMMsgStore where
   mkQueue _ rId qr = STMQueue rId <$> newTVarIO (Just qr) <*> newTVarIO Nothing
   {-# INLINE mkQueue #-}
 
+  getCachedQueue :: STMMsgStore -> STMQueue -> STM (Maybe STMQueue)
+  getCachedQueue _ = pure . Just
+  {-# INLINE getCachedQueue #-}
+
   getMsgQueue :: STMMsgStore -> STMQueue -> Bool -> STM STMMsgQueue
   getMsgQueue _ STMQueue {msgQueue'} _ = readTVar msgQueue' >>= maybe newQ pure
     where

--- a/src/Simplex/Messaging/Server/MsgStore/Types.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/Types.hs
@@ -35,7 +35,9 @@ class (Monad (StoreMonad s), QueueStoreClass (StoreQueue s) (QueueStore s)) => M
   newMsgStore :: MsgStoreConfig s -> IO s
   closeMsgStore :: s -> IO ()
   withActiveMsgQueues :: Monoid a => s -> (StoreQueue s -> IO a) -> IO a
-  withAllMsgQueues :: Monoid a => Bool -> s -> (StoreQueue s -> IO a) -> IO a
+  -- This function can only be used in server CLI commands or before server is started.
+  unsafeWithAllMsgQueues :: Monoid a => Bool -> s -> (StoreQueue s -> IO a) -> IO a
+  withAllMsgQueues :: Monoid a => Bool -> String -> s -> (StoreQueue s -> StoreMonad s a) -> IO a
   logQueueStates :: s -> IO ()
   logQueueState :: StoreQueue s -> StoreMonad s ()
   queueStore :: s -> QueueStore s
@@ -57,6 +59,7 @@ class (Monad (StoreMonad s), QueueStoreClass (StoreQueue s) (QueueStore s)) => M
   tryPeekMsg_ :: StoreQueue s -> MsgQueue (StoreQueue s) -> StoreMonad s (Maybe Message)
   tryDeleteMsg_ :: StoreQueue s -> MsgQueue (StoreQueue s) -> Bool -> StoreMonad s ()
   isolateQueue :: StoreQueue s -> String -> StoreMonad s a -> ExceptT ErrorType IO a
+  unsafeRunStore :: StoreQueue s -> String -> StoreMonad s a -> IO a
 
 data MSType = MSMemory | MSJournal
 
@@ -82,10 +85,6 @@ getQueueRec :: (MsgStoreClass s, DirectParty p) => s -> SParty p -> QueueId -> I
 getQueueRec st party qId =
   getQueue st party qId
     $>>= (\q -> maybe (Left AUTH) (Right . (q,)) <$> readTVarIO (queueRec q))
-
-getQueueMessages :: MsgStoreClass s => Bool -> s -> StoreQueue s -> ExceptT ErrorType IO [Message]
-getQueueMessages drainMsgs st q = withPeekMsgQueue st q "getQueueMessages" $ maybe (pure []) (getQueueMessages_ drainMsgs q . fst)
-{-# INLINE getQueueMessages #-}
 
 getQueueSize :: MsgStoreClass s => s -> StoreQueue s -> ExceptT ErrorType IO Int
 getQueueSize st q = withPeekMsgQueue st q "getQueueSize" $ maybe (pure 0) (getQueueSize_ . fst)
@@ -125,13 +124,12 @@ deleteExpiredMsgs st q old =
 
 -- closed and idle queues will be closed after expiration
 -- returns (expired count, queue size after expiration)
-idleDeleteExpiredMsgs :: MsgStoreClass s => Int64 -> s -> StoreQueue s -> Int64 -> ExceptT ErrorType IO (Maybe Int, Int)
-idleDeleteExpiredMsgs now st q old =
-  isolateQueue q "idleDeleteExpiredMsgs" $ do
-    -- Use cached queue if available.
-    -- Also see the comment in cachedOrLoadedQueue
-    q' <- getLoadedQueue st q
-    withIdleMsgQueue now st q' $ deleteExpireMsgs_ old q'
+idleDeleteExpiredMsgs :: MsgStoreClass s => Int64 -> s -> StoreQueue s -> Int64 -> StoreMonad s (Maybe Int, Int)
+idleDeleteExpiredMsgs now st q old = do
+  -- Use cached queue if available.
+  -- Also see the comment in cachedOrLoadedQueue
+  q' <- getLoadedQueue st q
+  withIdleMsgQueue now st q' $ deleteExpireMsgs_ old q'
 
 deleteExpireMsgs_ :: MsgStoreClass s => Int64 -> StoreQueue s -> MsgQueue (StoreQueue s) -> StoreMonad s Int
 deleteExpireMsgs_ old q mq = do

--- a/src/Simplex/Messaging/Server/MsgStore/Types.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/Types.hs
@@ -21,7 +21,6 @@ import Control.Monad.Trans.Except
 import Data.Functor (($>))
 import Data.Int (Int64)
 import Data.Kind
-import Data.Maybe (fromMaybe)
 import Data.Time.Clock.System (SystemTime (systemSeconds))
 import Simplex.Messaging.Protocol
 import Simplex.Messaging.Server.QueueStore
@@ -43,7 +42,7 @@ class (Monad (StoreMonad s), QueueStoreClass (StoreQueue s) (QueueStore s)) => M
 
   -- message store methods
   mkQueue :: s -> RecipientId -> QueueRec -> IO (StoreQueue s)
-  getCachedQueue :: s -> StoreQueue s -> StoreMonad s (Maybe (StoreQueue s))
+  getLoadedQueue :: s -> StoreQueue s -> StoreMonad s (StoreQueue s)
   getMsgQueue :: s -> StoreQueue s -> Bool -> StoreMonad s (MsgQueue (StoreQueue s))
   getPeekMsgQueue :: s -> StoreQueue s -> StoreMonad s (Maybe (MsgQueue (StoreQueue s), Message))
 
@@ -129,11 +128,9 @@ deleteExpiredMsgs st q old =
 idleDeleteExpiredMsgs :: MsgStoreClass s => Int64 -> s -> StoreQueue s -> Int64 -> ExceptT ErrorType IO (Maybe Int, Int)
 idleDeleteExpiredMsgs now st q old =
   isolateQueue q "idleDeleteExpiredMsgs" $ do
-    -- This check of the queue in the cache after the lock is taken prevents processing
-    -- of the queue instance that may have been cached by another thread
-    -- between reading queueRec in withAllMessages and taking this lock.
+    -- Use cached queue if available.
     -- Also see the comment in cachedOrLoadedQueue
-    q' <- fromMaybe q <$> getCachedQueue st q
+    q' <- getLoadedQueue st q
     withIdleMsgQueue now st q' $ deleteExpireMsgs_ old q'
 
 deleteExpireMsgs_ :: MsgStoreClass s => Int64 -> StoreQueue s -> MsgQueue (StoreQueue s) -> StoreMonad s Int

--- a/src/Simplex/Messaging/Server/MsgStore/Types.hs
+++ b/src/Simplex/Messaging/Server/MsgStore/Types.hs
@@ -127,7 +127,7 @@ deleteExpiredMsgs st q old =
 idleDeleteExpiredMsgs :: MsgStoreClass s => Int64 -> s -> StoreQueue s -> Int64 -> StoreMonad s (Maybe Int, Int)
 idleDeleteExpiredMsgs now st q old = do
   -- Use cached queue if available.
-  -- Also see the comment in cachedOrLoadedQueue
+  -- Also see the comment in loadQueue in PostgresQueueStore
   q' <- getLoadedQueue st q
   withIdleMsgQueue now st q' $ deleteExpireMsgs_ old q'
 

--- a/src/Simplex/Messaging/Server/QueueStore/Postgres.hs
+++ b/src/Simplex/Messaging/Server/QueueStore/Postgres.hs
@@ -328,7 +328,7 @@ insertQueueQuery =
 foldQueueRecs :: Monoid a => Bool -> PostgresQueueStore q -> ((RecipientId, QueueRec) -> IO a) -> IO a
 foldQueueRecs tty st f = do
   (n, r) <- withConnection (dbStore st) $ \db ->
-    DB.foldWithOptions_ opts db (queueRecQuery <> " WHERE deleted_at IS NULL") (0 :: Int, mempty) $ \(i, acc) row -> do
+    DB.fold_ db (queueRecQuery <> " WHERE deleted_at IS NULL") (0 :: Int, mempty) $ \(i, acc) row -> do
       r <- f $ rowToQueueRec row
       let !i' = i + 1
           !acc' = acc <> r
@@ -337,7 +337,6 @@ foldQueueRecs tty st f = do
   when tty $ putStrLn $ progress n
   pure r
   where
-    opts = DB.defaultFoldOptions {DB.fetchQuantity = DB.Fixed 16}
     progress i = "Processed: " <> show i <> " records"
 
 queueRecQuery :: Query

--- a/tests/CoreTests/MsgStoreTests.hs
+++ b/tests/CoreTests/MsgStoreTests.hs
@@ -453,7 +453,7 @@ testExpireIdleQueues = do
   old <- expireBeforeEpoch ExpirationConfig {ttl = 1, checkInterval = 1} -- no old messages
   now <- systemSeconds <$> getSystemTime
 
-  (expired_, stored) <- runRight $ idleDeleteExpiredMsgs now ms q old
+  (expired_, stored) <- runRight $ isolateQueue q "" $ idleDeleteExpiredMsgs now ms q old
   expired_ `shouldBe` Just 0
   stored `shouldBe` 0
   (Nothing, False) <- readQueueState ms statePath


### PR DESCRIPTION
It no longer caches all queues while expiring, but it still creates locks for all queues - so further improvement possible.