### PR TITLE
Fix typo in pqdr.md

### DIFF
--- a/protocol/pqdr.md
+++ b/protocol/pqdr.md
@@ -193,7 +193,7 @@ It is worth noting that while DH agreements work as ping-pong, when the new rece
 
 ## Implementation considerations for SimpleX Messaging Protocol
 
-As SimpleX Messaging Protocol pads messages to a fixed size, using 16kb transport blocks, the size increase introduced by this scheme can be compensated for by using ZSTD encryption of JSON bodies and image previews encoded as base64. While there may be some rare cases of random texts that would fail to compress, in all real scenarios it would not cause the message size reduction.
+As SimpleX Messaging Protocol pads messages to a fixed size, using 16kb transport blocks, the size increase introduced by this scheme can be compensated for by using ZSTD compression of JSON bodies and image previews encoded as base64. While there may be some rare cases of random texts that would fail to compress, in all real scenarios it would not cause the message size reduction.
 
 Sharing the initial keys in case of SimpleX Chat it is equivalent to sharing the invitation link. As encapsulation key is large, it may be inconvenient to share it in the link in some contexts, e.g. when QR codes are used.
 


### PR DESCRIPTION
Change the word "encryption" to "compression"; typo as ZSTD is a compression rather than a crypt algorithm.