### PR TITLE
v6.4.3.0 Update simplexmq.cabal

### DIFF
--- a/simplexmq.cabal
+++ b/simplexmq.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           simplexmq
-version:        6.4.1.0
+version:        6.4.3.0
 synopsis:       SimpleXMQ message broker
 description:    This package includes <./docs/Simplex-Messaging-Server.html server>,
                 <./docs/Simplex-Messaging-Client.html client> and


### PR DESCRIPTION
Hello,
Maybe that's why I can't build from sources using my distribution (Debian 12 amd64 and arm64) because 6.4.1.0 already exists and is up-to-date.