### PR TITLE
smp server: fix missing web page information

### DIFF
--- a/apps/smp-server/web/Static.hs
+++ b/apps/smp-server/web/Static.hs
@@ -237,8 +237,8 @@ section_ label content' src =
         (inside, next') ->
           let next = B.drop (B.length endMarker) next'
            in case content' of
-                Just content | not (B.null content) -> before <> item_ label content inside <> section_ label content' next
-                _ -> before <> next -- collapse section
+                Nothing -> before <> next -- collapse section
+                Just content -> before <> item_ label content inside <> section_ label content' next
   where
     startMarker = "<x-" <> label <> ">"
     endMarker = "</x-" <> label <> ">"


### PR DESCRIPTION
PR #1608 introduced a bug that made only some of the information about the server generated on the web page.