### PR TITLE
Add comments explaining widget init and event bubbling

### DIFF
--- a/xftp-web/package.json
+++ b/xftp-web/package.json
@@ -34,11 +34,11 @@
     "test:page": "playwright test test/page.spec.ts"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@types/libsodium-wrappers-sumo": "^0.7.8",
     "@types/node": "^20.0.0",
     "@types/pako": "^2.0.3",
     "@vitest/browser": "^3.0.0",
-    "@playwright/test": "^1.50.0",
     "playwright": "^1.50.0",
     "typescript": "^5.4.0",
     "vite": "^6.0.0",

--- a/xftp-web/web/main.ts
+++ b/xftp-web/web/main.ts
@@ -23,6 +23,7 @@ async function main() {
     })
   }
   await wasmReady
+// Allow parent elements/document to listen for readiness event via event bubbling
   app?.dispatchEvent(new CustomEvent('xftp:ready', {bubbles: true}))
 }
 
@@ -42,7 +43,7 @@ function initApp() {
     initUpload(app)
   }
 }
-
+// Expose manual init hook for embedded/widget-based integrations
 ;(window as any).__xftp_initApp = async () => { await wasmReady; initApp() }
 
 main().catch(err => {


### PR DESCRIPTION
Adds small explanatory comments in `main.ts` around:
embedded/widget initialization hook
 readiness event bubbling behavior

While exploring the XFTP web client architecture.
