### PR TITLE
xftp: gate web downloads on selected replicas

### DIFF
--- a/apps/xftp-server/static/xftp-web-bundle/index.js
+++ b/apps/xftp-server/static/xftp-web-bundle/index.js
@@ -674,13 +674,25 @@ function getDescriptionServers(fd) {
   const servers = [];
   for (const chunk of fd.chunks) {
     for (const replica of chunk.replicas) {
-      if (!seen.has(replica.server)) {
-        seen.add(replica.server);
-        servers.push(parseXFTPServer(replica.server));
-      }
+      addServer(servers, seen, replica.server);
     }
   }
   return servers;
+}
+function getDownloadServers(fd) {
+  const seen = /* @__PURE__ */ new Set();
+  const servers = [];
+  for (const chunk of fd.chunks) {
+    const replica = chunk.replicas[0];
+    if (replica) addServer(servers, seen, replica.server);
+  }
+  return servers;
+}
+function addServer(servers, seen, address) {
+  if (!seen.has(address)) {
+    seen.add(address);
+    servers.push(parseXFTPServer(address));
+  }
 }
 function serverOrigin(server) {
   return server.port === "443" ? `https://${server.host}` : `https://${server.host}:${server.port}`;
@@ -11428,7 +11440,7 @@ function initDownload(app, hash) {
     app.innerHTML = `<div class="card"><p class="error">${t("invalidLink", "Invalid or corrupted link.")}</p></div>`;
     return;
   }
-  const wrongServer = !getDescriptionServers(fd).map((s) => s.host).includes(window.location.hostname);
+  const wrongServer = !getDownloadServers(fd).map((s) => s.host).includes(window.location.hostname);
   const size = fd.redirect ? fd.redirect.size : fd.size;
   app.innerHTML = `
     <div class="card">

--- a/tests/XFTPWebTests.hs
+++ b/tests/XFTPWebTests.hs
@@ -14,7 +14,7 @@
 module XFTPWebTests (xftpWebTests) where
 
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar)
-import Control.Monad (replicateM, when)
+import Control.Monad (forM_, replicateM, when)
 import Crypto.Error (throwCryptoError)
 import qualified Crypto.PubKey.Curve25519 as X25519
 import qualified Crypto.PubKey.Ed25519 as Ed25519
@@ -170,6 +170,7 @@ jsOut expr = "process.stdout.write(Buffer.from(" <> expr <> "));"
 
 xftpWebTests :: IO () -> Spec
 xftpWebTests dbCleanup = do
+  xftpWebSourceHygieneTests
   distExists <- runIO $ doesDirectoryExist (xftpWebDir <> "/dist")
   if distExists
     then do
@@ -192,6 +193,19 @@ xftpWebTests dbCleanup = do
     else
       it "skipped (run 'cd xftp-web && npm install && npm run build' first)" $
         pendingWith "TS project not compiled"
+
+xftpWebSourceHygieneTests :: Spec
+xftpWebSourceHygieneTests = describe "source hygiene" $
+  it "gates XFTP web downloads on first-replica servers" $ do
+    let expectations =
+          [ ("xftp-web/src/protocol/address.ts", "export function getDownloadServers"),
+            ("xftp-web/web/download.ts", "getDownloadServers(fd)"),
+            ("apps/xftp-server/static/xftp-web-bundle/index.js", "function getDownloadServers"),
+            ("apps/xftp-server/static/xftp-web-bundle/index.js", "getDownloadServers(fd)")
+          ]
+    forM_ expectations $ \(path, marker) -> do
+      contents <- B.readFile path
+      contents `shouldSatisfy` B.isInfixOf marker
 
 -- ── protocol/encoding ──────────────────────────────────────────────
 
@@ -2827,6 +2841,26 @@ tsAddressTests = describe "protocol/address" $ do
           <> "const s = Addr.parseXFTPServer('xftp://LcJUMfVhwD8yxjAiSaDzzGF3-kLG4Uh0Fl_ZIjrRwjI=@host1.com:5000,host2.com');"
           <> jsOut "new TextEncoder().encode(s.host + ':' + s.port)"
     result `shouldBe` "host1.com:5000"
+
+  it "getDownloadServers returns only first replicas" $ do
+    result <-
+      callNode $
+        impAddr
+          <> "const kh = 'LcJUMfVhwD8yxjAiSaDzzGF3-kLG4Uh0Fl_ZIjrRwjI=';\
+             \const fd = {chunks: [\
+             \  {replicas: [\
+             \    {server: `xftp://${kh}@first.example:443`},\
+             \    {server: `xftp://${kh}@allowed.example:443`}\
+             \  ]},\
+             \  {replicas: [\
+             \    {server: `xftp://${kh}@second.example:443`},\
+             \    {server: `xftp://${kh}@allowed.example:443`}\
+             \  ]}\
+             \]};\
+             \const allHosts = Addr.getDescriptionServers(fd).map(s => s.host).join(',');\
+             \const downloadHosts = Addr.getDownloadServers(fd).map(s => s.host).join(',');"
+          <> jsOut "new TextEncoder().encode(allHosts + '|' + downloadHosts)"
+    result `shouldBe` "first.example,allowed.example,second.example|first.example,second.example"
 
 -- ── integration ───────────────────────────────────────────────────
 

--- a/xftp-web/src/protocol/address.ts
+++ b/xftp-web/src/protocol/address.ts
@@ -59,13 +59,28 @@ export function getDescriptionServers(fd: {chunks: {replicas: {server: string}[]
   const servers: XFTPServer[] = []
   for (const chunk of fd.chunks) {
     for (const replica of chunk.replicas) {
-      if (!seen.has(replica.server)) {
-        seen.add(replica.server)
-        servers.push(parseXFTPServer(replica.server))
-      }
+      addServer(servers, seen, replica.server)
     }
   }
   return servers
+}
+
+// Extract unique XFTP servers that downloadFileRaw will actually contact.
+export function getDownloadServers(fd: {chunks: {replicas: {server: string}[]}[]}): XFTPServer[] {
+  const seen = new Set<string>()
+  const servers: XFTPServer[] = []
+  for (const chunk of fd.chunks) {
+    const replica = chunk.replicas[0]
+    if (replica) addServer(servers, seen, replica.server)
+  }
+  return servers
+}
+
+function addServer(servers: XFTPServer[], seen: Set<string>, address: string) {
+  if (!seen.has(address)) {
+    seen.add(address)
+    servers.push(parseXFTPServer(address))
+  }
 }
 
 // Build an HTTPS origin from an XFTP server address.

--- a/xftp-web/web/download.ts
+++ b/xftp-web/web/download.ts
@@ -6,7 +6,7 @@ import {
   newXFTPAgent, closeXFTPAgent,
   decodeDescriptionURI, downloadFileRaw
 } from '../src/agent.js'
-import {getDescriptionServers} from '../src/protocol/address.js'
+import {getDownloadServers} from '../src/protocol/address.js'
 import {XFTPPermanentError} from '../src/client.js'
 
 const DECRYPT_WEIGHT = 0.15
@@ -22,7 +22,7 @@ export function initDownload(app: HTMLElement, hash: string) {
     return
   }
 
-  const wrongServer = !getDescriptionServers(fd).map(s => s.host).includes(window.location.hostname)
+  const wrongServer = !getDownloadServers(fd).map(s => s.host).includes(window.location.hostname)
 
   const size = fd.redirect ? fd.redirect.size : fd.size
   app.innerHTML = `


### PR DESCRIPTION
## Summary
- Add `getDownloadServers` to return the first-replica servers that the download path actually contacts.
- Switch the XFTP web download host gate to use those selected download servers.
- Update the committed static xftp-web bundle and add regression coverage for first-replica behavior.

## Tests
- `git diff --check upstream/master..HEAD`
- `npm install --cache /private/var/folders/xg/y64hd3px7h5_5qbwynrwx5xr0000gn/T/codex-npm-cache --no-package-lock --ignore-scripts`
- `npm run build`
- Attempted: `cabal test simplexmq-test --test-option=--match --test-option='gates XFTP web downloads on first-replica servers'`
- Blocked locally by the sandbox permission profile denying `.pem` fixture files during Cabal dependency checkout.

Note: `npm install` reported two existing critical advisories in the xftp-web dependency tree; this PR does not change dependencies.