### PR TITLE
smp: disable embedded web in cloud scripts without certs

### DIFF
--- a/scripts/smp-server-digitalocean-droplet/files/opt/simplex/initialize_server.sh
+++ b/scripts/smp-server-digitalocean-droplet/files/opt/simplex/initialize_server.sh
@@ -22,7 +22,7 @@ smp-server --version
 
 # Initialize server
 ip_address=$(curl ifconfig.me)
-smp-server init -l --ip $ip_address
+smp-server init -l --disable-web --ip $ip_address
 
 # Server fingerprint
 fingerprint=$(cat /etc/opt/simplex/fingerprint)

--- a/scripts/smp-server-digitalocean-droplet/files/opt/simplex/on_login.sh
+++ b/scripts/smp-server-digitalocean-droplet/files/opt/simplex/on_login.sh
@@ -12,6 +12,11 @@ Check SMP server status with: systemctl status smp-server
 To keep this server secure, the UFW firewall is enabled.
 All ports are BLOCKED except 22 (SSH), 443 (HTTPS), 5223 (SMP server).
 
+Embedded HTTPS web is disabled because this image does not provision
+/etc/opt/simplex/web.crt or /etc/opt/simplex/web.key. To enable it, provision
+those files, uncomment WEB https/cert/key in /etc/opt/simplex/smp-server.ini,
+and restart smp-server.
+
 ********************************************************************************
 To stop seeing this message delete line - bash /opt/simplex/on_login.sh - from /root/.bashrc
 EOF

--- a/scripts/smp-server-linode.sh
+++ b/scripts/smp-server-linode.sh
@@ -75,6 +75,9 @@ init_opts=()
 
 [[ $ENABLE_STORE_LOG == "on" ]] && init_opts+=(-l)
 
+# This script does not provision /etc/opt/simplex/web.crt or web.key.
+init_opts+=(--disable-web)
+
 ip_address=$(curl ifconfig.me)
 init_opts+=(--ip $ip_address)
 
@@ -110,6 +113,11 @@ Check SMP server status with: systemctl status smp-server
 
 To keep this server secure, the UFW firewall is enabled.
 All ports are BLOCKED except 22 (SSH), 443 (HTTPS), 5223 (SMP server).
+
+Embedded HTTPS web is disabled because this script does not provision
+/etc/opt/simplex/web.crt or /etc/opt/simplex/web.key. To enable it, provision
+those files, uncomment WEB https/cert/key in /etc/opt/simplex/smp-server.ini,
+and restart smp-server.
 
 ********************************************************************************
 To stop seeing this message delete line - bash /opt/simplex/on_login.sh - from /root/.bashrc

--- a/tests/CLITests.hs
+++ b/tests/CLITests.hs
@@ -13,7 +13,7 @@ import qualified Crypto.PubKey.RSA as RSA
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.HashMap.Strict as HM
 import Data.Ini (Ini (..), lookupValue, readIniFile, writeIniFile)
-import Data.List (isPrefixOf)
+import Data.List (isInfixOf, isPrefixOf)
 import qualified Data.Text as T
 import qualified Data.X509 as X
 import qualified Data.X509.File as XF
@@ -85,6 +85,7 @@ cliTests = do
       it "no store log, no password" $ smpServerTest False False
       it "with store log, no password" $ smpServerTest True False
       it "static files" smpServerTestStatic
+      it "cloud scripts disable embedded web without certificates" smpCloudScriptsDisableWeb
 #if defined(dbServerPostgres)
   around_ (postgressBracket ntfTestServerDBConnectInfo) $ before_ (createNtfSchema ntfTestServerDBConnectInfo ntfTestStoreDBOpts) $
     describe "Ntf server CLI" $ do
@@ -199,6 +200,23 @@ smpServerTestStatic = do
     getCerts tls =
       let X.CertificateChain cc = tlsPeerCert tls
        in map (X.signedObject . X.getSigned) cc
+
+smpCloudScriptsDisableWeb :: HasCallStack => IO ()
+smpCloudScriptsDisableWeb = do
+  linode <- readFile "scripts/smp-server-linode.sh"
+  digitalOceanInit <-
+    readFile "scripts/smp-server-digitalocean-droplet/files/opt/simplex/initialize_server.sh"
+  digitalOceanLogin <-
+    readFile "scripts/smp-server-digitalocean-droplet/files/opt/simplex/on_login.sh"
+  linode `shouldSatisfy` ("init_opts+=(--disable-web)" `isInfixOf`)
+  linode `shouldSatisfy` ("web.crt" `isInfixOf`)
+  linode `shouldSatisfy` ("web.key" `isInfixOf`)
+  linode `shouldSatisfy` ("uncomment WEB https/cert/key" `isInfixOf`)
+  digitalOceanInit
+    `shouldSatisfy` ("smp-server init -l --disable-web --ip $ip_address" `isInfixOf`)
+  digitalOceanLogin `shouldSatisfy` ("web.crt" `isInfixOf`)
+  digitalOceanLogin `shouldSatisfy` ("web.key" `isInfixOf`)
+  digitalOceanLogin `shouldSatisfy` ("uncomment WEB https/cert/key" `isInfixOf`)
 
 #if defined(dbServerPostgres)
 createNtfSchema :: PSQL.ConnectInfo -> DBOpts -> IO ()


### PR DESCRIPTION
## Summary
- Disable embedded web in the Linode and DigitalOcean setup scripts because they do not provision web TLS certificates.
- Add login guidance for enabling embedded web after provisioning `/etc/opt/simplex/web.crt` and `/etc/opt/simplex/web.key`.
- Add a CLI test that checks the cloud scripts disable embedded web and document the certificate steps.

## Tests
- `bash -n scripts/smp-server-linode.sh`
- `bash -n scripts/smp-server-digitalocean-droplet/files/opt/simplex/initialize_server.sh`
- `bash -n scripts/smp-server-digitalocean-droplet/files/opt/simplex/on_login.sh`
- `git diff --check origin/stable..HEAD`
- `cabal test simplexmq-test -fserver_postgres --extra-include-dirs=/opt/homebrew/opt/openssl@3/include --extra-lib-dirs=/opt/homebrew/opt/openssl@3/lib --test-option=--match --test-option='cloud scripts disable embedded web without certificates'`