### PR TITLE
xftp: recreate work directory if missing before creating transfer prefix path

### DIFF
--- a/src/Simplex/FileTransfer/Agent.hs
+++ b/src/Simplex/FileTransfer/Agent.hs
@@ -159,6 +159,9 @@ downloadChunk _ _ = throwE $ INTERNAL "no replicas"
 getPrefixPath :: String -> AM' FilePath
 getPrefixPath suffix = do
   workPath <- getXFTPWorkPath
+  -- re-create the work directory if it was removed while the app was running,
+  -- otherwise the non-recursive createDirectory on the returned prefix path fails
+  createDirectoryIfMissing True workPath
   ts <- liftIO getCurrentTime
   let isoTime = formatTime defaultTimeLocale "%Y%m%d_%H%M%S_%6q" ts
   uniqueCombine workPath (isoTime <> "_" <> suffix)

--- a/tests/XFTPAgent.hs
+++ b/tests/XFTPAgent.hs
@@ -42,7 +42,7 @@ import Simplex.Messaging.Encoding.String (StrEncoding (..))
 import Simplex.Messaging.Protocol (BasicAuth, NetworkError (..), ProtoServerWithAuth (..), ProtocolServer (..), XFTPServerWithAuth)
 import Simplex.Messaging.Server.Expiration (ExpirationConfig (..))
 import Simplex.Messaging.Util (tshow)
-import System.Directory (doesDirectoryExist, doesFileExist, getFileSize, listDirectory, removeFile)
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getFileSize, listDirectory, removeDirectoryRecursive, removeFile)
 import System.FilePath ((</>))
 import Test.Hspec hiding (fit, it)
 import UnliftIO
@@ -74,6 +74,7 @@ xftpAgentTests =
       it "should resume receiving file after restart" $ \_ -> testXFTPAgentReceiveRestore
       it "should cleanup rcv tmp path after permanent error" $ \_ -> testXFTPAgentReceiveCleanup
       it "should resume sending file after restart" $ \_ -> testXFTPAgentSendRestore
+      it "should recreate work directory removed while running before sending" $ withXFTPServer testXFTPAgentSendWorkDirRecreated
       xit'' "should cleanup snd prefix path after permanent error" $ \_ -> testXFTPAgentSendCleanup
       it "should delete sent file on server" testXFTPAgentDelete
       it "should resume deleting file after restart" $ \_ -> testXFTPAgentDeleteRestore
@@ -142,6 +143,23 @@ testXFTPAgentSendReceive = do
       withAgent clientId agentCfg initAgentServers testDB2 $ \rcp -> do
         rfId <- runRight $ testReceive rcp rfd originalFilePath
         xftpDeleteRcvFile rcp rfId
+
+-- regression test: the XFTP work directory can be removed while the app is running
+-- (temp/disk cleaner, roaming-profile sync, manual deletion). Sending a file must
+-- recreate the work directory instead of failing with "createDirectory ...: does not exist".
+testXFTPAgentSendWorkDirRecreated :: HasCallStack => IO ()
+testXFTPAgentSendWorkDirRecreated = do
+  filePath <- createRandomFile
+  let workDir = senderFiles </> "work"
+  withAgent 1 agentCfg initAgentServers testDB $ \sndr -> runRight_ $ do
+    liftIO $ createDirectoryIfMissing True workDir
+    xftpStartWorkers sndr (Just workDir)
+    -- remove the work directory after workers started, before sending
+    liftIO $ removeDirectoryRecursive workDir
+    sfId <- xftpSendFile sndr 1 (CF.plain filePath) 2
+    sfProgress sndr $ mb 18
+    ("", sfId', SFDONE _ _) <- sfGet sndr
+    liftIO $ sfId' `shouldBe` sfId
 
 testXFTPAgentSendReceiveEncrypted :: HasCallStack => AFStoreType -> IO ()
 testXFTPAgentSendReceiveEncrypted = withXFTPServer $ do


### PR DESCRIPTION
## Problem

`xftpSendFile'`, `xftpSendDescription'` and `xftpReceiveFile'` create their per-transfer work directory with a **non-recursive** `createDirectory` on the path from `getPrefixPath`, which assumes the configured XFTP work directory already exists. If that directory is removed while the app is running (third-party temp/disk cleaner, roaming-profile sync, or manual deletion), every subsequent transfer fails and cannot recover until the app is restarted.

Reported from simplex-chat desktop (Windows):

```
CreateDirectory "\\?\C:\Users\<user>\AppData\Roaming\SimpleX\tmp\20260701_231208_256584_snd.xftp": does not exist
```

`...\Roaming\SimpleX\tmp` is the work directory; it is created once at startup but never re-created before a transfer.

## Root cause

`src/Simplex/FileTransfer/Agent.hs`:

```haskell
getPrefixPath suffix = do
  workPath <- getXFTPWorkPath           -- not guaranteed to still exist
  ...
  uniqueCombine workPath (isoTime <> "_" <> suffix)

-- callers:
prefixPath <- lift $ getPrefixPath "snd.xftp"
createDirectory prefixPath              -- non-recursive; throws if workPath is gone
```

## Fix

Ensure the work directory exists in `getPrefixPath` with `createDirectoryIfMissing True`. This is a single point that covers all three transfer entry points (send, send-description, receive) and the chunk/tmp paths built from `getXFTPWorkPath` via `toFSFilePath`. The individual `createDirectory prefixPath` calls are unchanged — `uniqueCombine` still yields a fresh name.

```haskell
getPrefixPath suffix = do
  workPath <- getXFTPWorkPath
  createDirectoryIfMissing True workPath
  ...
```

## Testing

Added a regression test (`should recreate work directory removed while running before sending`) that removes the agent work directory after workers start, then sends a file.

Verified red→green locally (GHC 9.6.3), running only the new test:

- **Without** the fix: `1 example, 1 failure` — `createDirectory: does not exist` on `…/work/<ts>_snd.xftp` (reproduces the reported error).
- **With** the fix: `1 example, 0 failures`.

The full `/XFTP/XFTP agent/` group also passes with the fix (`27 examples, 0 failures, 1 pending`), confirming no regression to normal transfers.

## Notes

- `createDirectoryIfMissing` is already in scope (`import UnliftIO.Directory`).
- Non-recursive `createDirectory` calls that build paths **inside** an already-created `prefixPath` are intentionally left as-is; their parent exists by construction.
