### PR TITLE
docker: show smp-server init errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ On Linux, you can deploy smp and xftp server using Docker. This will download im
 
    - `smp-server`
 
-     You must change **your_ip_or_domain**. `-e "pass=password"` is optional variable to password-protect your `smp` server:
+     You must change **your_ip_or_domain**. `-e "PASS=password"` is optional variable to password-protect your `smp` server. Passwords can contain printable ASCII characters except whitespace, `@`, `:` and `/`:
      ```sh
      docker run -d \
          -e "ADDR=your_ip_or_domain" \
@@ -188,7 +188,7 @@ On Linux, you can build smp server using Docker.
 
    - `smp-server`
 
-     You must change **your_ip_or_domain**. `-e "pass=password"` is optional variable to password-protect your `smp` server:
+     You must change **your_ip_or_domain**. `-e "PASS=password"` is optional variable to password-protect your `smp` server. Passwords can contain printable ASCII characters except whitespace, `@`, `:` and `/`:
      ```sh
      docker run -d \
          -e "ADDR=your_ip_or_domain" \

--- a/scripts/docker/entrypoint-smp-server
+++ b/scripts/docker/entrypoint-smp-server
@@ -63,7 +63,7 @@ if [ ! -f "${confd}/smp-server.ini" ]; then
                   --store-log \
                   --daily-stats \
                   --source-code \
-                  "$@" > /dev/null 2>&1
+                  "$@" > /dev/null
 
   # Fix path to certificates
   if [ -n "${WEB_MANUAL}" ]; then

--- a/src/Simplex/Messaging/Server/Main.hs
+++ b/src/Simplex/Messaging/Server/Main.hs
@@ -409,7 +409,7 @@ smpServerCLI_ generateSite serveStaticFiles attachStaticFiles cfgPath logPath =
             s ->
               case strDecode $ encodeUtf8 $ T.pack s of
                 Right auth -> pure . Just $ ServerPassword auth
-                _ -> putStrLn "Invalid password. Only latin letters, digits and symbols other than '@' and ':' are allowed" >> serverPassword
+                _ -> putStrLn "Invalid password. Passwords can contain printable ASCII characters except whitespace, '@', ':' and '/'" >> serverPassword
         checkInitOptions InitOptions {sourceCode, serverInfo, operatorCountry, hostingCountry} = do
           let err_
                 | isNothing sourceCode && hasServerInfo serverInfo =


### PR DESCRIPTION
Addresses #1781

`entrypoint-smp-server` was redirecting both stdout and stderr from `smp-server init`, so Docker init failures could make the container exit without any useful logs

This keeps normal init output quiet while leaving stderr visible in container logs. It also documents the existing `PASS` constraints from `BasicAuth` and aligns the interactive init error message with the same rule

Tests:
- `sh -n scripts/docker/entrypoint-smp-server`
- `git diff --check`
- `cabal build exe:smp-server --ghc-options -O0 -j1`
- local entrypoint smoke check with a failing `smp-server init` stub
- `smp-server init --yes --ip 127.0.0.1 --password 'passw@rd'` rejects the password on stderr