### PR TITLE
transport server: bind to the address family enabled on the host

### DIFF
--- a/src/Simplex/Messaging/Transport/Server.hs
+++ b/src/Simplex/Messaging/Transport/Server.hs
@@ -24,6 +24,7 @@ module Simplex.Messaging.Transport.Server
     runTransportServerSocket,
     runLocalTCPServer,
     startTCPServer,
+    startTCPServerConfigured,
     loadServerCredential,
     loadFingerprint,
     loadFileFingerprint,
@@ -52,7 +53,7 @@ import Simplex.Messaging.Transport
 import Simplex.Messaging.Transport.Shared
 import Simplex.Messaging.Util (catchAll_, labelMyThread, tshow, unlessM)
 import System.Exit (exitFailure)
-import System.IO.Error (tryIOError)
+import System.IO.Error (catchIOError, tryIOError)
 import System.Mem.Weak (Weak, deRefWeak)
 import UnliftIO (timeout)
 import UnliftIO.Concurrent
@@ -230,11 +231,30 @@ closeServer started clients sock = do
   readTVarIO clients >>= mapM_ (deRefWeak >=> mapM_ killThread)
   void . atomically $ tryPutTMVar started False
 
+-- | Start TCP server binding to IPv6 wildcard address (dual stack), when host is not passed.
+-- It fails when IPv6 is not supported by the host, e.g. disabled in the kernel.
 startTCPServer :: TMVar Bool -> Maybe HostName -> ServiceName -> IO Socket
-startTCPServer started host port = withSocketsDo $ resolve >>= open >>= setStarted
+startTCPServer = startTCPServer_ False
+
+-- | Start TCP server binding to the wildcard address of the family enabled on the host, when host is not passed.
+--
+-- It should only be used for the servers that have to accept connections when IPv6 is disabled,
+-- e.g. remote control server on the desktop, as its address is advertised as IPv4 in the invitation.
+startTCPServerConfigured :: TMVar Bool -> Maybe HostName -> ServiceName -> IO Socket
+startTCPServerConfigured = startTCPServer_ True
+
+startTCPServer_ :: Bool -> TMVar Bool -> Maybe HostName -> ServiceName -> IO Socket
+startTCPServer_ addrConfig started host port = withSocketsDo $ resolve >>= open >>= setStarted
   where
-    resolve =
-      let hints = defaultHints {addrFlags = [AI_PASSIVE], addrSocketType = Stream}
+    -- AI_ADDRCONFIG excludes address families that have no address configured on any interface,
+    -- so IPv6 wildcard address is only chosen when IPv6 is enabled, and IPv4 wildcard address is used otherwise.
+    -- Some systems do not report configured families in all cases (e.g., Windows does not count
+    -- loopback addresses), so when resolution with this flag fails the addresses are resolved without it.
+    resolve
+      | addrConfig = resolveWith [AI_PASSIVE, AI_ADDRCONFIG] `catchIOError` \_ -> resolveWith [AI_PASSIVE]
+      | otherwise = resolveWith [AI_PASSIVE]
+    resolveWith addrFlags =
+      let hints = defaultHints {addrFlags, addrSocketType = Stream}
        in select <$> getAddrInfo (Just hints) host (Just port)
     select as = fromJust $ family AF_INET6 <|> family AF_INET
       where

--- a/src/Simplex/RemoteControl/Discovery.hs
+++ b/src/Simplex/RemoteControl/Discovery.hs
@@ -35,7 +35,7 @@ import qualified Network.UDP as UDP
 import Simplex.Messaging.Transport (TransportPeer (..), defaultSupportedParams)
 import qualified Simplex.Messaging.Transport as Transport
 import Simplex.Messaging.Transport.Client (TransportHost (..))
-import Simplex.Messaging.Transport.Server (mkTransportServerConfig, runTransportServerSocket, startTCPServer)
+import Simplex.Messaging.Transport.Server (mkTransportServerConfig, runTransportServerSocket, startTCPServerConfigured)
 import Simplex.Messaging.Util (ifM, tshow)
 import Simplex.RemoteControl.Discovery.Multicast (setMembership)
 import Simplex.RemoteControl.Types
@@ -80,7 +80,7 @@ preferAddress RCCtrlAddress {address, interface} addrs =
 startTLSServer :: Maybe Word16 -> TMVar (Maybe N.PortNumber) -> TLS.Credential -> TLS.ServerHooks -> (Transport.TLS 'TServer -> IO ()) -> IO (Async ())
 startTLSServer port_ startedOnPort credentials hooks server = async . liftIO $ do
   started <- newEmptyTMVarIO
-  bracketOnError (startTCPServer started Nothing $ maybe "0" show port_) (\_e -> setPort Nothing) $ \socket ->
+  bracketOnError (startTCPServerConfigured started Nothing $ maybe "0" show port_) (\_e -> setPort Nothing) $ \socket ->
     ifM
       (atomically $ readTMVar started)
       (runServer started socket)


### PR DESCRIPTION
Connecting a mobile to the desktop fails when IPv6 is disabled in the kernel (`ipv6.disable=1`) — simplex-chat/simplex-chat#5515, simplex-chat/simplex-chat#3531.

`startTCPServer` resolves the wildcard address with `AI_PASSIVE` only, and then `select` picks the IPv6 address whenever one is returned:

```haskell
let hints = defaultHints {addrFlags = [AI_PASSIVE], addrSocketType = Stream}
 in select <$> getAddrInfo (Just hints) host (Just port)
select as = fromJust $ family AF_INET6 <|> family AF_INET
```

`getaddrinfo` returns `::` even when the host has no IPv6 at all, so the filter selects it and `socket AF_INET6` throws `EAFNOSUPPORT`.

`AI_ADDRCONFIG` is the missing part of the filter: it excludes the address families that have no address configured on any interface. This adds `startTCPServerConfigured`, which passes it, and uses it for the remote control TLS server — the only listener that has to accept connections on an IPv6-less host, as its address is advertised as IPv4 in the invitation.

`startTCPServer` itself is unchanged: SMP/XFTP/ntf servers and the local TCP server keep requiring IPv6, and still fail if it is disabled.

### Measured

Calling the two functions from this branch with `host = Nothing`:

| host state | `startTCPServer` | `startTCPServerConfigured` |
|---|---|---|
| IPv6 enabled | `[::]` | `[::]` |
| `ipv6.disable=1` (no IPv6 addresses, `socket(AF_INET6)` → EAFNOSUPPORT) | `Network.Socket.socket: unsupported operation (Address family not supported by protocol)` | `0.0.0.0` |
| `net.ipv6.conf.all.disable_ipv6=1` | `[::]` | `0.0.0.0` |

Verified in a network namespace — the third row with the real sysctl, the second with an `LD_PRELOAD` shim making `socket(AF_INET6)` return `EAFNOSUPPORT` on top of a namespace with no IPv6 addresses. Also checked that `AI_ADDRCONFIG` never empties the result: on a host with no addresses configured at all glibc falls back to returning both families, so `fromJust` in `select` stays safe.

Verified with the XRCP pairing tests, run in a namespace with `disable_ipv6=1` plus an `LD_PRELOAD` shim making `socket(AF_INET6)` return `EAFNOSUPPORT`:

- with `startTCPServer` (before this change) the tests **hang** — the bind throws inside `bracketOnError`'s acquire, so `startedPort` is never filled and `readTMVar` blocks;
- with `startTCPServerConfigured` they pass in 2.3s (3/3 repeat runs).

`SMP server via TLS` (37 tests) passes unchanged, and the strict `startTCPServer` still binds `[::]` in every state measured.

Two notes on `AI_ADDRCONFIG` semantics that shaped the patch. It keys off configured addresses rather than socket support, so a host that has IPv6 addresses (link-local included) but cannot create `AF_INET6` sockets would still fail — a combination neither `ipv6.disable=1` nor `disable_ipv6=1` produces, as both remove every IPv6 address. And glibc counts only non-loopback addresses, falling back to returning all families when none are configured, while [Windows documents that loopback is not a valid global address](https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo) and promises no such fallback — hence resolving again without the flag if the flagged call fails, so an offline Windows desktop keeps binding as it does today.

Supersedes the earlier `catchAny`-on-bind version of this PR, which worked around the selection instead of fixing it.
