### PR TITLE
smp server: fix handshake compatibility by moving server info to SMP v21

### DIFF
--- a/protocol/simplex-messaging.md
+++ b/protocol/simplex-messaging.md
@@ -1,4 +1,4 @@
-Version 20, 2026-05-25
+Version 21, 2026-07-05
 
 # Simplex Messaging Protocol (SMP)
 
@@ -107,6 +107,7 @@ This document describes SMP protocol version 20. Versions 1-5 are discontinued. 
 - v18: support client notices in BLOCKED error
 - v19: service subscriptions to messages (SUBS, NSUBS, SOKS, ENDS, ALLS commands)
 - v20: public namespaces resolver (RSLV command, RNAME response) — direct or forwarded via PFWD
+- v21: server public information in handshake
 
 ## Introduction
 

--- a/src/Simplex/Messaging/Transport.hs
+++ b/src/Simplex/Messaging/Transport.hs
@@ -169,7 +169,8 @@ smpBlockSize = 16384
 -- 17 - create notification credentials with NEW (7/12/2025)
 -- 18 - support client notices (10/10/2025)
 -- 19 - service subscriptions to messages (10/20/2025)
--- 20 - server public information in handshake (7/5/2026)
+-- 20 - public namespaces resolver, RSLV command (6/20/2026)
+-- 21 - server public information in handshake (7/5/2026)
 
 data SMPVersion
 
@@ -204,7 +205,7 @@ namesSMPVersion :: VersionSMP
 namesSMPVersion = VersionSMP 20
 
 serverInfoSMPVersion :: VersionSMP
-serverInfoSMPVersion = VersionSMP 20
+serverInfoSMPVersion = VersionSMP 21
 
 minClientSMPRelayVersion :: VersionSMP
 minClientSMPRelayVersion = VersionSMP 14
@@ -213,10 +214,10 @@ minServerSMPRelayVersion :: VersionSMP
 minServerSMPRelayVersion = VersionSMP 14
 
 currentClientSMPRelayVersion :: VersionSMP
-currentClientSMPRelayVersion = VersionSMP 20
+currentClientSMPRelayVersion = VersionSMP 21
 
 currentServerSMPRelayVersion :: VersionSMP
-currentServerSMPRelayVersion = VersionSMP 20
+currentServerSMPRelayVersion = VersionSMP 21
 
 -- Max SMP protocol version to be used in e2e encrypted connection between
 -- client and server, as defined by SMP proxy. Normally set below the current


### PR DESCRIPTION
## Problem
private routing `server master -> server 7.0.0.6` fails during the transport handshake:

```
Forwarding server: smp://…@localhost:5223
Error: TRANSPORT {transportErr = TEHandshake {handshakeErr = PARSE}}
```

## Root cause
`serverInfoSMPVersion` was defined as `VersionSMP 20`, the same version already released as `namesSMPVersion` (public namespaces resolver, #1784). This made a v20 handshake ambiguous on the wire:
- Released v20 (namespaces) servers advertise max version 20 but send **no** `serverInfo` field.
- Server expects `serverInfo` that isn't there

The issue appeared since 62e39ae - rewrote the `SMPServerHandshake` parser from `(fmap unLarge <$> smpP) <|> pure Nothing` to `unLarge <$$> smpP`, dropping the `<|> pure Nothing` fallback that had been masking the collision.

## Fix
Give server info its own protocol version instead of overlapped v20:
- `serverInfoSMPVersion` → `VersionSMP 21`
- `currentClientSMPRelayVersion` / `currentServerSMPRelayVersion` → 21

With `serverInfoSMPVersion = 21`, `ifHasServerInfo` is false for a v20 handshake, so the parser never looks for `serverInfo`